### PR TITLE
feat: era5-rwrf inference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+run:
+	rm -rf /home/master/14/andrewhsu/.cache/uv/environments-v2/09-1-stormcast-example-*
+	uv run --refresh examples/09-1_stormcast_example.py 
+
 install:
 	uv sync
 	uv sync --extra all --extra aifs

--- a/checkpoints/.gitignore
+++ b/checkpoints/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/earth2studio/data/__init__.py
+++ b/earth2studio/data/__init__.py
@@ -27,6 +27,7 @@ from .ifs import IFS
 from .imerg import IMERG
 from .ncar import NCAR_ERA5
 from .rand import Random, Random_FX
+from .rwrf import RWRF, RWRF_FX
 from .rx import CosineSolarZenith, LandSeaMask, SurfaceGeoPotential
 from .utils import datasource_to_file, fetch_data, prep_data_array
 from .wb2 import WB2ERA5, WB2Climatology, WB2ERA5_32x64, WB2ERA5_121x240

--- a/earth2studio/data/rwrf.py
+++ b/earth2studio/data/rwrf.py
@@ -269,12 +269,12 @@ class RWRF:
             Timestamps to return data for (UTC).
         variable : str | list[str] | VariableArray
             String, list of strings or array of strings that refer to variables to
-            return. Must be in the HRRR lexicon.
+            return. Must be in the RWRF lexicon.
 
         Returns
         -------
         xr.DataArray
-            HRRR weather data array
+            RWRF weather data array
         """
         if self.fs is None:
             raise ValueError(
@@ -298,7 +298,7 @@ class RWRF:
         else:
             session = None
 
-        # Generate HRRR lat-lon grid to append onto data array
+        # Generate RWRF lat-lon grid to append onto data array
         lat, lon = self.grid() #? fix this grid coordinates
         # Note, this could be more memory efficient and avoid pre-allocation of the array
         # but this is much much cleaner to deal with

--- a/earth2studio/data/rwrf.py
+++ b/earth2studio/data/rwrf.py
@@ -1,0 +1,931 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import concurrent.futures
+import functools
+import hashlib
+import os
+import pathlib
+import shutil
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import gcsfs
+import nest_asyncio
+import numpy as np
+import s3fs
+import xarray as xr
+from fsspec.implementations.http import HTTPFileSystem
+from loguru import logger
+from tqdm.asyncio import tqdm
+
+from earth2studio.data.utils import (
+    datasource_cache_root,
+    prep_data_inputs,
+    prep_forecast_inputs,
+)
+from earth2studio.lexicon import HRRRFXLexicon, HRRRLexicon
+from earth2studio.utils.imports import (
+    OptionalDependencyFailure,
+    check_optional_dependencies,
+)
+from earth2studio.utils.type import LeadTimeArray, TimeArray, VariableArray
+
+try:
+    import pyproj
+except ImportError:
+    OptionalDependencyFailure("data")
+    pyproj = None
+
+logger.remove()
+logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
+
+# Silence FutureWarning from cfgrib
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+
+@dataclass
+class RWRFAsyncTask:
+    """Small helper struct for Async tasks"""
+
+    data_array_indices: tuple[int, int, int]
+    hrrr_file_uri: str
+    hrrr_byte_offset: int
+    hrrr_byte_length: int
+    hrrr_modifier: Callable
+
+
+@check_optional_dependencies()
+class RWRF:
+    """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
+    weather analysis data developed by NOAA (used to initialize the HRRR forecast
+    model). This data source is provided on a Lambert conformal 3km grid at 1-hour
+    intervals. The spatial dimensionality of HRRR data is [1059, 1799].
+
+    Parameters
+    ----------
+    source : str, optional
+        Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
+    max_workers : int, optional
+        Max works in async io thread pool. Only applied when using sync call function
+        and will modify the default async loop if one exists, by default 24
+    cache : bool, optional
+        Cache data source on local memory, by default True
+    verbose : bool, optional
+        Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
+
+    Warning
+    -------
+    This is a remote data source and can potentially download a large amount of data
+    to your local machine for large requests.
+
+    Note
+    ----
+    Additional information on the data repository can be referenced here:
+
+    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
+    - https://rapidrefresh.noaa.gov/hrrr/
+    - https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
+    - https://hrrrzarr.s3.amazonaws.com/index.html
+    - https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+    """
+
+    HRRR_BUCKET_NAME = "noaa-hrrr-bdp-pds"
+    MAX_BYTE_SIZE = 5000000
+
+    # HRRR_X = np.arange(1799)
+    RWRF_X = np.arange(450)
+    # HRRR_Y = np.arange(1059)
+    RWRF_Y = np.arange(450)
+
+    def __init__(
+        self,
+        source: str = "aws",
+        max_workers: int = 24,
+        cache: bool = True,
+        verbose: bool = True,
+        async_timeout: int = 600,
+    ):
+        self._source = source
+        self._cache = cache
+        self._verbose = verbose
+        self._max_workers = max_workers
+
+        self.lexicon = HRRRLexicon
+        self.async_timeout = async_timeout
+
+        if self._source == "aws":
+            self.uri_prefix = "noaa-hrrr-bdp-pds"
+
+            # To update look at https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
+            def _range(time: datetime) -> None:
+                # sfc goes back to 2016 for anl, limit based on pressure
+                # frst starts on on the same date pressure starts
+                if time < datetime(year=2018, month=7, day=12, hour=13):
+                    raise ValueError(
+                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
+                    )
+
+            self._history_range = _range
+        elif self._source == "google":
+            self.uri_prefix = "high-resolution-rapid-refresh"
+
+            # To update look at https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+            # Needs confirmation
+            def _range(time: datetime) -> None:
+                # sfc goes back to 2016 for anl, limit based on pressure
+                # frst starts on on the same date pressure starts
+                if time < datetime(year=2018, month=7, day=12, hour=13):
+                    raise ValueError(
+                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
+                    )
+
+            self._history_range = _range
+        elif self._source == "azure":
+            raise NotImplementedError(
+                "Azure data source not implemented yet, open an issue if needed"
+            )
+        elif self._source == "nomads":
+            # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
+            self.uri_prefix = (
+                "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
+            )
+
+            def _range(time: datetime) -> None:
+                if time + timedelta(days=2) < datetime.today():
+                    raise ValueError(
+                        f"Requested date time {time} needs to be within past 2 days for HRRR nomads source"
+                    )
+
+            self._history_range = _range
+        else:
+            raise ValueError(f"Invalid HRRR source { self._source}")
+
+        try:
+            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
+            loop = asyncio.get_running_loop()
+            loop.run_until_complete(self._async_init())
+        except RuntimeError:
+            # Else we assume that async calls will be used which in that case
+            # we will init the group in the call function when we have the loop
+            self.fs = None
+
+    async def _async_init(self) -> None:
+        """Async initialization of fsspec file stores
+
+        Note
+        ----
+        Async fsspec expects initialization inside of the execution loop
+        """
+        if self._source == "aws":
+            self.fs = s3fs.S3FileSystem(anon=True, client_kwargs={}, asynchronous=True)
+        elif self._source == "google":
+            fs = gcsfs.GCSFileSystem(
+                cache_timeout=-1,
+                token="anon",  # noqa: S106 # nosec B106
+                access="read_only",
+                block_size=8**20,
+            )
+            fs._loop = asyncio.get_event_loop()
+            self.fs = fs
+        elif self._source == "azure":
+            raise NotImplementedError(
+                "Azure data source not implemented yet, open an issue if needed"
+            )
+        elif self._source == "nomads":
+            # HTTP file system, tried FTP but didnt work
+            self.fs = HTTPFileSystem(asynchronous=True)
+
+    def __call__(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve HRRR analysis data (lead time 0)
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            HRRR weather data array
+        """
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If no event loop exists, create one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Modify the worker amount
+        loop.set_default_executor(
+            concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers)
+        )
+
+        if self.fs is None:
+            loop.run_until_complete(self._async_init())
+
+        # xr_array = loop.run_until_complete(
+        #     asyncio.wait_for(self.fetch(time, variable), timeout=self.async_timeout)
+        # )
+        xr_array = loop.run_until_complete(self.fetch(time, variable))
+        return xr_array
+
+    async def fetch(
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async function to get data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            HRRR weather data array
+        """
+        if self.fs is None:
+            raise ValueError(
+                "File store is not initialized! If you are calling this \
+            function directly make sure the data source is initialized inside the async \
+            loop!"
+            )
+
+        time, variable = prep_data_inputs(time, variable)
+        logger.info(f"Stormcast time: {time}")
+        logger.info(f"Stormcast vars: {variable}")
+        # Create cache dir if doesnt exist
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        # Make sure input time is valid
+        self._validate_time(time)
+
+        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
+        if isinstance(self.fs, s3fs.S3FileSystem):
+            session = await self.fs.set_session()
+        else:
+            session = None
+
+        # Generate HRRR lat-lon grid to append onto data array
+        lat, lon = self.grid() #? fix this grid coordinates
+        # Note, this could be more memory efficient and avoid pre-allocation of the array
+        # but this is much much cleaner to deal with
+        xr_array = xr.DataArray(
+            data=np.zeros(
+                (
+                    len(time),
+                    1,
+                    len(variable),
+                    len(self.RWRF_Y),
+                    len(self.RWRF_X),
+                )
+            ),
+            dims=["time", "lead_time", "variable", "rwrf_y", "rwrf_x"],
+            coords={
+                "time": time,
+                "lead_time": [timedelta(hours=0)],
+                "variable": variable,
+                "rwrf_x": self.RWRF_X,
+                "rwrf_y": self.RWRF_Y,
+                "lat": (("rwrf_y", "rwrf_x"), lat),
+                "lon": (("rwrf_y", "rwrf_x"), lon),
+            },
+        )
+        
+        date_str = "2019/08/03"
+        hr_str = str(0).zfill(2)
+        
+        dt = datetime.strptime(date_str, "%Y/%m/%d")
+        fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
+        folder = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
+        filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp"
+
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"File not found: {filepath}")
+
+        ds = xr.open_dataset(filepath)
+        
+        var_map = {
+            "t2m": "T2",
+            "u10m": "umet10",
+            # add any others here...
+        }
+        
+        # # Loop through each requested variable and fill the xr_array
+        for j, var in enumerate(variable):
+            # Check if the variable exists in the NetCDF file
+            if var in var_map:
+                # Extract the data and assign it to the correct slice
+                # This assumes the WRF data has dimensions that match rwrf_y, rwrf_x
+                data_slice = ds.variables[var_map.get(var, var)].isel(Time=0).values
+                xr_array[0, 0, j, :, :] = data_slice
+            else:
+                logger.warning(f"Variable '{var}' not found in {filepath}. Filling with random numbers.")
+                xr_array[0, 0, j, :, :] = np.random.rand(len(self.RWRF_Y), len(self.RWRF_X))
+
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        if session:
+            await session.close()
+
+        xr_array = xr_array.isel(lead_time=0)
+        del xr_array.coords["lead_time"]
+        return xr_array
+
+    async def _create_tasks(
+        self, time: list[datetime], lead_time: list[timedelta], variable: list[str]
+    ) -> list[RWRFAsyncTask]:
+        """Create download tasks, each corresponding to one grib byte range
+
+        Parameters
+        ----------
+        times : list[datetime]
+            Timestamps to be downloaded (UTC).
+        variables : list[str]
+            List of variables to be downloaded.
+
+        Returns
+        -------
+        list[dict]
+            List of download tasks
+        """
+        tasks: list[RWRFAsyncTask] = []  # group pressure-level variables
+
+        # Start with fetching all index files for each time / lead time
+        # TODO: Update so only needed products (can tell from parsing variables), for
+        # now fetch all index files because its cheap and easier
+        products = ["wrfsfc", "wrfprs", "wrfnat"]
+        args = [
+            self._grib_index_uri(t, lt, p)
+            for t in time
+            for lt in lead_time
+            for p in products
+        ]
+        func_map = map(self._fetch_index, args)
+        results = await tqdm.gather(
+            *func_map, desc="Fetching HRRR index files", disable=True
+        )
+        for i, t in enumerate(time):
+            for j, lt in enumerate(lead_time):
+                # Get index file dictionaries for each possible product
+                index_files = {p: results.pop(0) for p in products}
+                for k, v in enumerate(variable):
+                    try:
+                        hrrr_name_str, modifier = self.lexicon[v]  # type: ignore
+                        hrrr_name = hrrr_name_str.split("::") + ["", ""]
+                        product = hrrr_name[0]
+                        variable_name = hrrr_name[1]
+                        level = hrrr_name[2]
+                        forecastvld = hrrr_name[3]
+                        index = hrrr_name[4]
+
+                        # Create index key to find byte range
+                        hrrr_key = f"{variable_name}::{level}"
+                        if forecastvld:
+                            hrrr_key = f"{hrrr_key}::{forecastvld}"
+                        else:
+                            if lt.total_seconds() == 0:
+                                hrrr_key = f"{hrrr_key}::anl"
+                            else:
+                                hrrr_key = f"{hrrr_key}::{int(lt.total_seconds() // 3600):d} hour fcst"
+                        if index and index.isnumeric():
+                            hrrr_key = index
+
+                        # Special cases
+                        # could do this better with templates, but this is single instance
+                        if variable_name == "APCP":
+                            hours = int(lt.total_seconds() // 3600)
+                            hrrr_key = f"{variable_name}::{level}::{hours-1:d}-{hours:d} hour acc fcst"
+
+                    except KeyError as e:
+                        logger.error(
+                            f"variable id {variable} not found in HRRR lexicon"
+                        )
+                        raise e
+
+                    # Get byte range from index
+                    byte_offset = None
+                    byte_length = None
+                    for key, value in index_files[product].items():
+                        if hrrr_key in key:
+                            byte_offset = value[0]
+                            byte_length = value[1]
+                            break
+
+                    if byte_length is None or byte_offset is None:
+                        logger.warning(
+                            f"Variable {v} not found in index file for time {t} at {lt}, values will be unset"
+                        )
+                        continue
+
+                    tasks.append(
+                        RWRFAsyncTask(
+                            data_array_indices=(i, j, k),
+                            hrrr_file_uri=self._grib_uri(t, lt, product),
+                            hrrr_byte_offset=byte_offset,
+                            hrrr_byte_length=byte_length,
+                            hrrr_modifier=modifier,
+                        )
+                    )
+        return tasks
+
+    async def fetch_wrapper(
+        self,
+        task: RWRFAsyncTask,
+        xr_array: xr.DataArray,
+    ) -> xr.DataArray:
+        """Small wrapper to pack arrays into the DataArray"""
+        out = await self.fetch_array(
+            task.hrrr_file_uri,
+            task.hrrr_byte_offset,
+            task.hrrr_byte_length,
+            task.hrrr_modifier,
+        )
+        i, j, k = task.data_array_indices
+        xr_array[i, j, k] = out
+
+    async def fetch_array(
+        self,
+        grib_uri: str,
+        byte_offset: int,
+        byte_length: int,
+        modifier: Callable,
+    ) -> np.ndarray:
+        """Fetch HRRR data array. This will first fetch the index file to get byte range
+        of the needed data, fetch the respective grib files and lastly combining grib
+        files into single data array.
+
+        Parameters
+        ----------
+        time : datetime
+            Date time to fetch
+        lead_time : timedelta
+            Forecast lead time to fetch
+        variables : list[str]
+            Variables to fetch
+
+        Returns
+        -------
+        xr.DataArray
+            FS data array for given time and lead time
+        """
+        logger.debug(f"Fetching HRRR grib file: {grib_uri} {byte_offset}-{byte_length}")
+        # Download the grib file to cache
+        grib_file = await self._fetch_remote_file(
+            grib_uri,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+        )
+        # Open into xarray data-array
+        da = xr.open_dataarray(
+            grib_file, engine="cfgrib", backend_kwargs={"indexpath": ""}
+        )
+        return modifier(da.values)
+
+    def _validate_time(self, times: list[datetime]) -> None:
+        """Verify if date time is valid for HRRR based on offline knowledge
+
+        Parameters
+        ----------
+        times : list[datetime]
+            list of date times to fetch data
+        """
+        for time in times:
+            if not (time - datetime(1900, 1, 1)).total_seconds() % 3600 == 0:
+                raise ValueError(
+                    f"Requested date time {time} needs to be 1 hour interval for HRRR"
+                )
+            # Check history range for given source
+            self._history_range(time)
+
+    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int]]:
+        """Fetch HRRR atmospheric index file
+
+        Parameters
+        ----------
+        index_uri : str
+            URI to grib index file to download
+
+        Returns
+        -------
+        dict[str, tuple[int, int]]
+            Dictionary of HRRR vairables (byte offset, byte length)
+        """
+        # Grab index file
+        try:
+            index_file = await self._fetch_remote_file(index_uri)
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"The specified data index, {index_uri}, does not exist. Data seems to be missing."
+            )
+        with open(index_file) as file:
+            index_lines = [line.rstrip() for line in file]
+
+        index_table = {}
+        # Note we actually drop the last variable here because its easier (SBT114)
+        # GEFS has a solution for this if needed that involves appending a dummy line
+        # Example of row: "1:0:d=2021111823:REFC:entire atmosphere:795 min fcst:"
+        for i, line in enumerate(index_lines[:-1]):
+            lsplit = line.split(":")
+            if len(lsplit) < 7:
+                continue
+
+            nlsplit = index_lines[i + 1].split(":")
+            byte_length = int(nlsplit[1]) - int(lsplit[1])
+            byte_offset = int(lsplit[1])
+            key = f"{lsplit[0]}::{lsplit[3]}::{lsplit[4]}::{lsplit[5]}"
+            if byte_length > self.MAX_BYTE_SIZE:
+                raise ValueError(
+                    f"Byte length, {byte_length}, of variable {key} larger than safe threshold of {self.MAX_BYTE_SIZE}"
+                )
+
+            index_table[key] = (byte_offset, byte_length)
+
+        return index_table
+
+    async def _fetch_remote_file(
+        self, path: str, byte_offset: int = 0, byte_length: int | None = None
+    ) -> str:
+        """Fetches remote file into cache"""
+        if self.fs is None:
+            raise ValueError("File system is not initialized")
+
+        sha = hashlib.sha256((path + str(byte_offset)).encode())
+        filename = sha.hexdigest()
+        cache_path = os.path.join(self.cache, filename)
+
+        if not pathlib.Path(cache_path).is_file():
+            if self.fs.async_impl:
+                if byte_length:
+                    byte_length = int(byte_offset + byte_length)
+                data = await self.fs._cat_file(path, start=byte_offset, end=byte_length)
+            else:
+                data = await asyncio.to_thread(
+                    self.fs.read_block, path, offset=byte_offset, length=byte_length
+                )
+            with open(cache_path, "wb") as file:
+                await asyncio.to_thread(file.write, data)
+
+        return cache_path
+
+    def _grib_uri(
+        self, time: datetime, lead_time: timedelta, product: str = "wrfsfc"
+    ) -> str:
+        """Generates the URI for HRRR grib files"""
+        lead_hour = int(lead_time.total_seconds() // 3600)
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
+        file_name = os.path.join(
+            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2"
+        )
+        return os.path.join(self.uri_prefix, file_name)
+
+    def _grib_index_uri(
+        self, time: datetime, lead_time: timedelta, product: str
+    ) -> str:
+        """Generates the URI for HRRR index grib files"""
+        # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
+        lead_hour = int(lead_time.total_seconds() // 3600)
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
+        file_name = os.path.join(
+            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2.idx"
+        )
+        return os.path.join(self.uri_prefix, file_name)
+
+    @property
+    def cache(self) -> str:
+        """Return appropriate cache location."""
+        cache_location = os.path.join(datasource_cache_root(), "hrrr")
+        if not self._cache:
+            cache_location = os.path.join(cache_location, "tmp_hrrr")
+        return cache_location
+
+    @classmethod
+    def grid(cls) -> tuple[np.array, np.array]:
+        """Generates the HRRR lambert conformal projection grid coordinates. Creates the
+        HRRR grid using single parallel lambert conformal mapping
+
+        Note
+        ----
+        For more information about the HRRR grid see:
+
+        - https://ntrs.nasa.gov/api/citations/20160009371/downloads/20160009371.pdf
+
+        Returns
+        -------
+        Returns:
+            tuple: (lat, lon) in degrees
+        """
+        # lon_0, lat_0 is the center of the grid
+        # lat_1, lat_2 is the standard parallel
+        # a, b is radius of globe 6371229
+        p1 = pyproj.CRS(
+            "proj=lcc lon_0=121.75 lat_0=23.4 lat_1=22 lat_2=25 a=6371229 b=6371229"
+        )
+        p2 = pyproj.CRS("latlon")
+        transformer = pyproj.Transformer.from_proj(p2, p1)
+        itransformer = pyproj.Transformer.from_proj(p1, p2)
+
+        # Start with getting grid bounds based on lat / lon box (SW-NW-NE-SE)
+        # Ground-truth corner coordinates from the RWRF dataset [SW, NW, NE, SE]
+        # Extracted from the provided XLAT and XLONG variables.
+        lat = np.array(
+            [19.548283, 27.897097, 27.844585, 19.49942]
+        )
+        lon = np.array(
+            [116.37149, 116.11554, 125.56778, 125.20111]
+        )
+
+        # Transform lat/lon corners to projected easting/northing coordinates
+        easting, northing = transformer.transform(lat, lon)
+        nx = len(cls.RWRF_X)
+        ny = len(cls.RWRF_Y)
+        E, N = np.meshgrid(
+            np.linspace(easting[0], easting[2], nx),
+            np.linspace(northing[0], northing[1], ny),
+        )
+
+        lat, lon = itransformer.transform(E, N) # Transform the projected grid back
+        lon = np.where(lon < 0, lon + 360, lon)
+        return lat, lon
+
+    @classmethod
+    def available(
+        cls,
+        time: datetime | np.datetime64,
+    ) -> bool:
+        """Checks if given date time is avaliable in the HRRR object store. Uses S3
+        store
+
+        Parameters
+        ----------
+        time : datetime | np.datetime64
+            Date time to access
+
+        Returns
+        -------
+        bool
+            If date time is avaiable
+        """
+        if isinstance(time, np.datetime64):  # np.datetime64 -> datetime
+            _unix = np.datetime64(0, "s")
+            _ds = np.timedelta64(1, "s")
+            time = datetime.fromtimestamp((time - _unix) / _ds, timezone.utc)
+
+        fs = s3fs.S3FileSystem(anon=True)
+        # Object store directory for given time
+        # Just picking the first variable to look for
+        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus"
+        file_name = f"{file_name}/hrrr.t{time.hour:0>2}z.wrfnatf00.grib2.idx"
+        s3_uri = f"s3://{cls.HRRR_BUCKET_NAME}/{file_name}"
+        exists = fs.exists(s3_uri)
+
+        return exists
+
+
+class RWRF_FX(RWRF):
+    """High-Resolution Rapid Refresh (HRRR) forecast source provides a North-American
+    weather forecasts with hourly forecast runs developed by NOAA. This forecast source
+    has hourly forecast steps up to a lead time of 48 hours. Data is provided on a
+    Lambert conformal 3km grid at 1-hour intervals. The spatial dimensionality of HRRR
+    data is [1059, 1799].
+
+    Parameters
+    ----------
+    source : str, optional
+        Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
+    max_workers : int, optional
+        Max works in async io thread pool. Only applied when using sync call function
+        and will modify the default async loop if one exists, by default 24
+    cache : bool, optional
+        Cache data source on local memory, by default True
+    verbose : bool, optional
+        Print download progress, by default True
+    async_timeout : int, optional
+        Time in sec after which download will be cancelled if not finished successfully,
+        by default 600
+
+    Warning
+    -------
+    This is a remote data source and can potentially download a large amount of data
+    to your local machine for large requests.
+
+    Note
+    ----
+    48 hour forecasts are provided on 6 hour intervals. 18 hour forecasts are generated
+    hourly.
+
+    Note
+    ----
+    Additional information on the data repository can be referenced here:
+
+    - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
+    - https://rapidrefresh.noaa.gov/hrrr/
+    - https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
+    """
+
+    def __init__(
+        self,
+        source: str = "aws",
+        max_workers: int = 24,
+        cache: bool = True,
+        verbose: bool = True,
+        async_timeout: int = 600,
+    ):
+        super().__init__(
+            source=source,
+            max_workers=max_workers,
+            cache=cache,
+            verbose=verbose,
+            async_timeout=async_timeout,
+        )
+        self.lexicon = HRRRFXLexicon  # type: ignore
+
+    def __call__(  # type: ignore[override]
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Retrieve HRRR forecast data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            HRRR forecast data array
+        """
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # If no event loop exists, create one
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Modify the worker amount
+        loop.set_default_executor(
+            concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers)
+        )
+
+        if self.fs is None:
+            loop.run_until_complete(self._async_init())
+
+        xr_array = loop.run_until_complete(
+            asyncio.wait_for(
+                self.fetch(time, lead_time, variable), timeout=self.async_timeout
+            )
+        )
+
+        return xr_array
+
+    async def fetch(  # type: ignore[override]
+        self,
+        time: datetime | list[datetime] | TimeArray,
+        lead_time: timedelta | list[timedelta] | LeadTimeArray,
+        variable: str | list[str] | VariableArray,
+    ) -> xr.DataArray:
+        """Async function to get data
+
+        Parameters
+        ----------
+        time : datetime | list[datetime] | TimeArray
+            Timestamps to return data for (UTC).
+        lead_time: timedelta | list[timedelta] | LeadTimeArray
+            Forecast lead times to fetch.
+        variable : str | list[str] | VariableArray
+            String, list of strings or array of strings that refer to variables to
+            return. Must be in the HRRR FX lexicon.
+
+        Returns
+        -------
+        xr.DataArray
+            HRRR forecast data array
+        """
+        time, lead_time, variable = prep_forecast_inputs(time, lead_time, variable)
+        # Create cache dir if doesnt exist
+        pathlib.Path(self.cache).mkdir(parents=True, exist_ok=True)
+
+        # Make sure input time is valid
+        self._validate_time(time)
+        self._validate_leadtime(time, lead_time)
+
+        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
+        if isinstance(self.fs, s3fs.S3FileSystem):
+            session = await self.fs.set_session()
+        else:
+            session = None
+
+        # Note, this could be more memory efficient and avoid pre-allocation of the array
+        # but this is much much cleaner to deal with, compared to something seen in the
+        # NCAR data source.
+        xr_array = xr.DataArray(
+            data=np.empty(
+                (
+                    len(time),
+                    len(lead_time),
+                    len(variable),
+                    len(self.RWRF_Y),
+                    len(self.RWRF_X),
+                )
+            ),
+            dims=["time", "lead_time", "variable", "hrrr_y", "hrrr_x"],
+            coords={
+                "time": time,
+                "lead_time": lead_time,
+                "variable": variable,
+                "hrrr_x": self.RWRF_X,
+                "hrrr_y": self.RWRF_Y,
+            },
+        )
+
+        async_tasks = []
+        async_tasks = await self._create_tasks(time, lead_time, variable)
+        func_map = map(
+            functools.partial(self.fetch_wrapper, xr_array=xr_array), async_tasks
+        )
+
+        await tqdm.gather(
+            *func_map, desc="Fetching HRRR data", disable=(not self._verbose)
+        )
+
+        # Delete cache if needed
+        if not self._cache:
+            shutil.rmtree(self.cache)
+
+        # Close aiohttp client if s3fs
+        if session:
+            await session.close()
+
+        return xr_array
+
+    @classmethod
+    def _validate_leadtime(
+        cls, times: list[datetime], lead_times: list[timedelta]
+    ) -> None:
+        """Verify if lead time is valid for HRRR based on offline knowledge
+
+        Parameters
+        ----------
+        lead_times : list[timedelta]
+            list of lead times to fetch data
+        """
+        for time in times:
+            for delta in lead_times:
+                if not delta.total_seconds() % 3600 == 0:
+                    raise ValueError(
+                        f"Requested lead time {delta} needs to be 1 hour interval for HRRR"
+                    )
+                hours = int(delta.total_seconds() // 3600)
+                # Note, one forecasts every 6 hours have 2 day lead times, others only have 18 hours
+                if hours > 48 or hours < 0:
+                    raise ValueError(
+                        f"Requested lead time {delta} can only be between [0,48] hours for HRRR forecast"
+                    )
+                if (
+                    not (time - datetime(1900, 1, 1)).total_seconds() % 21600 == 0
+                    and hours > 18
+                ):
+                    raise ValueError(
+                        f"Requested lead time {delta} can only be between [0,18] hours for HRRR forecast not on 6 hour interval {time}"
+                    )

--- a/earth2studio/data/rwrf.py
+++ b/earth2studio/data/rwrf.py
@@ -17,21 +17,15 @@
 import asyncio
 import concurrent.futures
 import functools
-import hashlib
 import os
 import pathlib
 import shutil
 import warnings
-from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-import gcsfs
-import nest_asyncio
 import numpy as np
 import s3fs
 import xarray as xr
-from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
 from tqdm.asyncio import tqdm
 
@@ -60,28 +54,18 @@ logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
-@dataclass
-class RWRFAsyncTask:
-    """Small helper struct for Async tasks"""
-
-    data_array_indices: tuple[int, int, int]
-    hrrr_file_uri: str
-    hrrr_byte_offset: int
-    hrrr_byte_length: int
-    hrrr_modifier: Callable
-
-
 @check_optional_dependencies()
 class RWRF:
-    """High-Resolution Rapid Refresh (HRRR) data source provides hourly North-American
-    weather analysis data developed by NOAA (used to initialize the HRRR forecast
-    model). This data source is provided on a Lambert conformal 3km grid at 1-hour
-    intervals. The spatial dimensionality of HRRR data is [1059, 1799].
+    """Radar Data Assimilation with WRFDA (RWRF) data source provides Taiwan weather analysis data developed by CWA. The radar observations possess high spatial resolution of approximately 1km and temporal resolutions of 5-10 minutes at a convective scale. The spatial dimensionality of RWRF data is [450, 450].
 
     Parameters
     ----------
-    source : str, optional
-        Data source to use ('aws', 'google', 'azure', 'nomads'), by default 'aws'
+    date_str : str, optional
+        Date string of RWRF data in the format "YYYY/MM/DD", by default "2019/08/03"
+    hr_str : int, optional
+        Hour string of RWRF data in the range of 0-23, by default 0
+    source_folder : str, optional
+        Path to the folder containing RWRF data, by default "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
     max_workers : int, optional
         Max works in async io thread pool. Only applied when using sync call function
         and will modify the default async loop if one exists, by default 24
@@ -100,32 +84,29 @@ class RWRF:
 
     Note
     ----
+    TODO fix the whole RWRF description
     Additional information on the data repository can be referenced here:
 
     - https://www.nco.ncep.noaa.gov/pmb/products/hrrr/
-    - https://rapidrefresh.noaa.gov/hrrr/
-    - https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
-    - https://hrrrzarr.s3.amazonaws.com/index.html
-    - https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
     """
 
-    HRRR_BUCKET_NAME = "noaa-hrrr-bdp-pds"
-    MAX_BYTE_SIZE = 5000000
-
-    # HRRR_X = np.arange(1799)
     RWRF_X = np.arange(450)
-    # HRRR_Y = np.arange(1059)
     RWRF_Y = np.arange(450)
 
     def __init__(
         self,
-        source: str = "aws",
+        date_str: str = "2019/08/03",
+        hr_str: int = 0,
+        source_folder: str = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf",
         max_workers: int = 24,
         cache: bool = True,
         verbose: bool = True,
         async_timeout: int = 600,
     ):
-        self._source = source
+        dt = datetime.strptime(date_str, "%Y/%m/%d")
+        dt_str = dt.strftime(f"%Y-%m-%d_{str(hr_str).zfill(2)}")
+        self._path = f"{source_folder}/{dt_str}/wrfout_d01_{dt_str}_interp"
+
         self._cache = cache
         self._verbose = verbose
         self._max_workers = max_workers
@@ -133,107 +114,36 @@ class RWRF:
         self.lexicon = HRRRLexicon
         self.async_timeout = async_timeout
 
-        if self._source == "aws":
-            self.uri_prefix = "noaa-hrrr-bdp-pds"
-
-            # To update look at https://aws.amazon.com/marketplace/pp/prodview-yd5ydptv3vuz2#resources
+        if os.path.exists(self._path):
+            # TODO: fix the range after all RWRF data is available
             def _range(time: datetime) -> None:
-                # sfc goes back to 2016 for anl, limit based on pressure
-                # frst starts on on the same date pressure starts
-                if time < datetime(year=2018, month=7, day=12, hour=13):
+                if time < datetime(year=2019, month=8, day=3):
                     raise ValueError(
-                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
-                    )
-
-            self._history_range = _range
-        elif self._source == "google":
-            self.uri_prefix = "high-resolution-rapid-refresh"
-
-            # To update look at https://console.cloud.google.com/marketplace/product/noaa-public/hrrr
-            # Needs confirmation
-            def _range(time: datetime) -> None:
-                # sfc goes back to 2016 for anl, limit based on pressure
-                # frst starts on on the same date pressure starts
-                if time < datetime(year=2018, month=7, day=12, hour=13):
-                    raise ValueError(
-                        f"Requested date time {time} needs to be after July 12th, 2018 13:00 for HRRR"
-                    )
-
-            self._history_range = _range
-        elif self._source == "azure":
-            raise NotImplementedError(
-                "Azure data source not implemented yet, open an issue if needed"
-            )
-        elif self._source == "nomads":
-            # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
-            self.uri_prefix = (
-                "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
-            )
-
-            def _range(time: datetime) -> None:
-                if time + timedelta(days=2) < datetime.today():
-                    raise ValueError(
-                        f"Requested date time {time} needs to be within past 2 days for HRRR nomads source"
+                        f"Requested date time {time} needs to be after August 3rd, 2019 00:00 for RWRF"
                     )
 
             self._history_range = _range
         else:
-            raise ValueError(f"Invalid HRRR source {self._source}")
-
-        try:
-            nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
-            loop = asyncio.get_running_loop()
-            loop.run_until_complete(self._async_init())
-        except RuntimeError:
-            # Else we assume that async calls will be used which in that case
-            # we will init the group in the call function when we have the loop
-            self.fs = None
-
-    async def _async_init(self) -> None:
-        """Async initialization of fsspec file stores
-
-        Note
-        ----
-        Async fsspec expects initialization inside of the execution loop
-        """
-        if self._source == "aws":
-            self.fs = s3fs.S3FileSystem(anon=True, client_kwargs={}, asynchronous=True)
-        elif self._source == "google":
-            fs = gcsfs.GCSFileSystem(
-                cache_timeout=-1,
-                token="anon",  # noqa: S106 # nosec B106
-                access="read_only",
-                block_size=8**20,
-            )
-            fs._loop = asyncio.get_event_loop()
-            self.fs = fs
-        elif self._source == "azure":
-            raise NotImplementedError(
-                "Azure data source not implemented yet, open an issue if needed"
-            )
-        elif self._source == "nomads":
-            # HTTP file system, tried FTP but didnt work
-            self.fs = HTTPFileSystem(asynchronous=True)
+            raise FileNotFoundError(f"Invalid RWRF source path {self._path}")
 
     def __call__(
         self,
         time: datetime | list[datetime] | TimeArray,
         variable: str | list[str] | VariableArray,
     ) -> xr.DataArray:
-        """Retrieve HRRR analysis data (lead time 0)
+        """Retrieve RWRF analysis data (lead time 0)
 
         Parameters
         ----------
         time : datetime | list[datetime] | TimeArray
             Timestamps to return data for (UTC).
         variable : str | list[str] | VariableArray
-            String, list of strings or array of strings that refer to variables to
-            return. Must be in the HRRR lexicon.
+            String, list of strings or array of strings that refer to variables to return. Must be in the RWRF lexicon.
 
         Returns
         -------
         xr.DataArray
-            HRRR weather data array
+            RWRF weather data array
         """
         try:
             loop = asyncio.get_event_loop()
@@ -247,13 +157,9 @@ class RWRF:
             concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers)
         )
 
-        if self.fs is None:
-            loop.run_until_complete(self._async_init())
-
-        # xr_array = loop.run_until_complete(
-        #     asyncio.wait_for(self.fetch(time, variable), timeout=self.async_timeout)
-        # )
-        xr_array = loop.run_until_complete(self.fetch(time, variable))
+        xr_array = loop.run_until_complete(
+            asyncio.wait_for(self.fetch(time, variable), timeout=self.async_timeout)
+        )
         return xr_array
 
     async def fetch(
@@ -276,12 +182,6 @@ class RWRF:
         xr.DataArray
             RWRF weather data array
         """
-        if self.fs is None:
-            raise ValueError(
-                "File store is not initialized! If you are calling this \
-            function directly make sure the data source is initialized inside the async \
-            loop!"
-            )
 
         time, variable = prep_data_inputs(time, variable)
         logger.info(f"Stormcast time: {time}")
@@ -291,12 +191,6 @@ class RWRF:
 
         # Make sure input time is valid
         self._validate_time(time)
-
-        # https://filesystem-spec.readthedocs.io/en/latest/async.html#using-from-async
-        if isinstance(self.fs, s3fs.S3FileSystem):
-            session = await self.fs.set_session()
-        else:
-            session = None
 
         # Generate RWRF lat-lon grid to append onto data array
         lat, lon = self.grid()
@@ -324,18 +218,7 @@ class RWRF:
             },
         )
 
-        date_str = "2019/08/03"
-        hr_str = str(0).zfill(2)
-
-        dt = datetime.strptime(date_str, "%Y/%m/%d")
-        fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
-        folder = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
-        filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp"
-
-        if not os.path.exists(filepath):
-            raise FileNotFoundError(f"File not found: {filepath}")
-
-        ds = xr.open_dataset(filepath)
+        ds = xr.open_dataset(self._path)
 
         var_map = {
             "t2m": "T2",
@@ -345,15 +228,12 @@ class RWRF:
 
         # # Loop through each requested variable and fill the xr_array
         for j, var in enumerate(variable):
-            # Check if the variable exists in the NetCDF file
             if var in var_map:
-                # Extract the data and assign it to the correct slice
-                # This assumes the WRF data has dimensions that match rwrf_y, rwrf_x
                 data_slice = ds.variables[var_map.get(var, var)].isel(Time=0).values
                 xr_array[0, 0, j, :, :] = data_slice
             else:
                 logger.warning(
-                    f"Variable '{var}' not found in {filepath}. Filling with random numbers."
+                    f"Variable '{var}' not found in {self._path}. Filling with random numbers."
                 )
                 xr_array[0, 0, j, :, :] = np.random.rand(
                     len(self.RWRF_Y), len(self.RWRF_X)
@@ -362,165 +242,12 @@ class RWRF:
         if not self._cache:
             shutil.rmtree(self.cache)
 
-        if session:
-            await session.close()
-
         xr_array = xr_array.isel(lead_time=0)
         del xr_array.coords["lead_time"]
         return xr_array
 
-    async def _create_tasks(
-        self, time: list[datetime], lead_time: list[timedelta], variable: list[str]
-    ) -> list[RWRFAsyncTask]:
-        """Create download tasks, each corresponding to one grib byte range
-
-        Parameters
-        ----------
-        times : list[datetime]
-            Timestamps to be downloaded (UTC).
-        variables : list[str]
-            List of variables to be downloaded.
-
-        Returns
-        -------
-        list[dict]
-            List of download tasks
-        """
-        tasks: list[RWRFAsyncTask] = []  # group pressure-level variables
-
-        # Start with fetching all index files for each time / lead time
-        # TODO: Update so only needed products (can tell from parsing variables), for
-        # now fetch all index files because its cheap and easier
-        products = ["wrfsfc", "wrfprs", "wrfnat"]
-        args = [
-            self._grib_index_uri(t, lt, p)
-            for t in time
-            for lt in lead_time
-            for p in products
-        ]
-        func_map = map(self._fetch_index, args)
-        results = await tqdm.gather(
-            *func_map, desc="Fetching HRRR index files", disable=True
-        )
-        for i, t in enumerate(time):
-            for j, lt in enumerate(lead_time):
-                # Get index file dictionaries for each possible product
-                index_files = {p: results.pop(0) for p in products}
-                for k, v in enumerate(variable):
-                    try:
-                        hrrr_name_str, modifier = self.lexicon[v]  # type: ignore
-                        hrrr_name = hrrr_name_str.split("::") + ["", ""]
-                        product = hrrr_name[0]
-                        variable_name = hrrr_name[1]
-                        level = hrrr_name[2]
-                        forecastvld = hrrr_name[3]
-                        index = hrrr_name[4]
-
-                        # Create index key to find byte range
-                        hrrr_key = f"{variable_name}::{level}"
-                        if forecastvld:
-                            hrrr_key = f"{hrrr_key}::{forecastvld}"
-                        else:
-                            if lt.total_seconds() == 0:
-                                hrrr_key = f"{hrrr_key}::anl"
-                            else:
-                                hrrr_key = f"{hrrr_key}::{int(lt.total_seconds() // 3600):d} hour fcst"
-                        if index and index.isnumeric():
-                            hrrr_key = index
-
-                        # Special cases
-                        # could do this better with templates, but this is single instance
-                        if variable_name == "APCP":
-                            hours = int(lt.total_seconds() // 3600)
-                            hrrr_key = f"{variable_name}::{level}::{hours - 1:d}-{hours:d} hour acc fcst"
-
-                    except KeyError as e:
-                        logger.error(
-                            f"variable id {variable} not found in HRRR lexicon"
-                        )
-                        raise e
-
-                    # Get byte range from index
-                    byte_offset = None
-                    byte_length = None
-                    for key, value in index_files[product].items():
-                        if hrrr_key in key:
-                            byte_offset = value[0]
-                            byte_length = value[1]
-                            break
-
-                    if byte_length is None or byte_offset is None:
-                        logger.warning(
-                            f"Variable {v} not found in index file for time {t} at {lt}, values will be unset"
-                        )
-                        continue
-
-                    tasks.append(
-                        RWRFAsyncTask(
-                            data_array_indices=(i, j, k),
-                            hrrr_file_uri=self._grib_uri(t, lt, product),
-                            hrrr_byte_offset=byte_offset,
-                            hrrr_byte_length=byte_length,
-                            hrrr_modifier=modifier,
-                        )
-                    )
-        return tasks
-
-    async def fetch_wrapper(
-        self,
-        task: RWRFAsyncTask,
-        xr_array: xr.DataArray,
-    ) -> xr.DataArray:
-        """Small wrapper to pack arrays into the DataArray"""
-        out = await self.fetch_array(
-            task.hrrr_file_uri,
-            task.hrrr_byte_offset,
-            task.hrrr_byte_length,
-            task.hrrr_modifier,
-        )
-        i, j, k = task.data_array_indices
-        xr_array[i, j, k] = out
-
-    async def fetch_array(
-        self,
-        grib_uri: str,
-        byte_offset: int,
-        byte_length: int,
-        modifier: Callable,
-    ) -> np.ndarray:
-        """Fetch HRRR data array. This will first fetch the index file to get byte range
-        of the needed data, fetch the respective grib files and lastly combining grib
-        files into single data array.
-
-        Parameters
-        ----------
-        time : datetime
-            Date time to fetch
-        lead_time : timedelta
-            Forecast lead time to fetch
-        variables : list[str]
-            Variables to fetch
-
-        Returns
-        -------
-        xr.DataArray
-            FS data array for given time and lead time
-        """
-        logger.debug(f"Fetching HRRR grib file: {grib_uri} {byte_offset}-{byte_length}")
-        # Download the grib file to cache
-        grib_file = await self._fetch_remote_file(
-            grib_uri,
-            byte_offset=byte_offset,
-            byte_length=byte_length,
-        )
-        # Open into xarray data-array
-        da = xr.open_dataarray(
-            grib_file, engine="cfgrib", backend_kwargs={"indexpath": ""}
-        )
-        return modifier(da.values)
-
     def _validate_time(self, times: list[datetime]) -> None:
-        """Verify if date time is valid for HRRR based on offline knowledge
+        """Verify if date time is valid for RWRF based on offline knowledge
 
         Parameters
         ----------
@@ -528,124 +255,69 @@ class RWRF:
             list of date times to fetch data
         """
         for time in times:
+            # TODO: fix this method after knowing RWRF intervals
             if not (time - datetime(1900, 1, 1)).total_seconds() % 3600 == 0:
                 raise ValueError(
                     f"Requested date time {time} needs to be 1 hour interval for HRRR"
                 )
-            # Check history range for given source
+            # Check history range for given path
             self._history_range(time)
 
-    async def _fetch_index(self, index_uri: str) -> dict[str, tuple[int, int]]:
-        """Fetch HRRR atmospheric index file
-
-        Parameters
-        ----------
-        index_uri : str
-            URI to grib index file to download
+    def get_global_attrs(
+        self,
+    ) -> dict:
+        """Get the global attributes of the RWRF dataset
 
         Returns
         -------
-        dict[str, tuple[int, int]]
-            Dictionary of HRRR vairables (byte offset, byte length)
+        dict
+            Dictionary of global attributes from the dataset.
         """
-        # Grab index file
-        try:
-            index_file = await self._fetch_remote_file(index_uri)
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                f"The specified data index, {index_uri}, does not exist. Data seems to be missing."
-            )
-        with open(index_file) as file:
-            index_lines = [line.rstrip() for line in file]
+        ds = xr.open_dataset(self._path, decode_coords=True, mask_and_scale=False)
+        logger.debug("RWRF dataset global attributes:")
+        for k, v in ds.attrs.items():
+            logger.debug(f"{k}: {v}")
 
-        index_table = {}
-        # Note we actually drop the last variable here because its easier (SBT114)
-        # GEFS has a solution for this if needed that involves appending a dummy line
-        # Example of row: "1:0:d=2021111823:REFC:entire atmosphere:795 min fcst:"
-        for i, line in enumerate(index_lines[:-1]):
-            lsplit = line.split(":")
-            if len(lsplit) < 7:
-                continue
+        return ds.attrs
 
-            nlsplit = index_lines[i + 1].split(":")
-            byte_length = int(nlsplit[1]) - int(lsplit[1])
-            byte_offset = int(lsplit[1])
-            key = f"{lsplit[0]}::{lsplit[3]}::{lsplit[4]}::{lsplit[5]}"
-            if byte_length > self.MAX_BYTE_SIZE:
-                raise ValueError(
-                    f"Byte length, {byte_length}, of variable {key} larger than safe threshold of {self.MAX_BYTE_SIZE}"
-                )
+    def get_lat_lon_bound(self) -> dict[str, tuple[float, float]]:
+        """Get the NW, SW, SE, NE latitude and longitude corners of the RWRF dataset.
 
-            index_table[key] = (byte_offset, byte_length)
+        Returns
+        -------
+        dict[str, tuple[float, float]]
+            Dictionary with keys 'NW', 'SW', 'SE', 'NE' and values (lat, lon)
+        """
+        ds = xr.open_dataset(self._path, decode_coords=True, mask_and_scale=False)
+        lat = ds.variables["XLAT"][0, ...]
+        lon = ds.variables["XLONG"][0, ...]
 
-        return index_table
-
-    async def _fetch_remote_file(
-        self, path: str, byte_offset: int = 0, byte_length: int | None = None
-    ) -> str:
-        """Fetches remote file into cache"""
-        if self.fs is None:
-            raise ValueError("File system is not initialized")
-
-        sha = hashlib.sha256((path + str(byte_offset)).encode())
-        filename = sha.hexdigest()
-        cache_path = os.path.join(self.cache, filename)
-
-        if not pathlib.Path(cache_path).is_file():
-            if self.fs.async_impl:
-                if byte_length:
-                    byte_length = int(byte_offset + byte_length)
-                data = await self.fs._cat_file(path, start=byte_offset, end=byte_length)
-            else:
-                data = await asyncio.to_thread(
-                    self.fs.read_block, path, offset=byte_offset, length=byte_length
-                )
-            with open(cache_path, "wb") as file:
-                await asyncio.to_thread(file.write, data)
-
-        return cache_path
-
-    def _grib_uri(
-        self, time: datetime, lead_time: timedelta, product: str = "wrfsfc"
-    ) -> str:
-        """Generates the URI for HRRR grib files"""
-        lead_hour = int(lead_time.total_seconds() // 3600)
-        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
-        file_name = os.path.join(
-            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2"
-        )
-        return os.path.join(self.uri_prefix, file_name)
-
-    def _grib_index_uri(
-        self, time: datetime, lead_time: timedelta, product: str
-    ) -> str:
-        """Generates the URI for HRRR index grib files"""
-        # https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/
-        lead_hour = int(lead_time.total_seconds() // 3600)
-        file_name = f"hrrr.{time.year}{time.month:0>2}{time.day:0>2}/conus/"
-        file_name = os.path.join(
-            file_name, f"hrrr.t{time.hour:0>2}z.{product}f{lead_hour:02d}.grib2.idx"
-        )
-        return os.path.join(self.uri_prefix, file_name)
+        corners = {
+            "SW": (lat[0, 0].item(), lon[0, 0].item()),
+            "NW": (lat[-1, 0].item(), lon[-1, 0].item()),
+            "NE": (lat[-1, -1].item(), lon[-1, -1].item()),
+            "SE": (lat[0, -1].item(), lon[0, -1].item()),
+        }
+        logger.debug(f"RWRF corners: {corners}")
+        return corners
 
     @property
     def cache(self) -> str:
         """Return appropriate cache location."""
-        cache_location = os.path.join(datasource_cache_root(), "hrrr")
+        cache_location = os.path.join(datasource_cache_root(), "rwrf")
         if not self._cache:
-            cache_location = os.path.join(cache_location, "tmp_hrrr")
+            cache_location = os.path.join(cache_location, "tmp_rwrf")
         return cache_location
 
     @classmethod
     def grid(cls) -> tuple[np.array, np.array]:
-        """Generates the RWRF lambert conformal projection grid coordinates. Creates the
-        RWRF grid using single parallel lambert conformal mapping
+        """Generates the RWRF lambert conformal projection grid coordinates. Creates the RWRF grid using a secant (parallel) Lambert conformal conic projection with two standard parallels for accurate mapping over Taiwan.
 
         Note
         ----
         For more information about the RWRF grid see:
 
-        - examples/09-1_stormcast_example.py:170
+        - examples/09-1_stormcast_example.py:135
 
         Returns
         -------
@@ -655,6 +327,7 @@ class RWRF:
         # lon_0, lat_0 is the center of the grid
         # lat_1, lat_2 is the standard parallel
         # a, b is radius of globe 6371229
+        # RWRF().get_global_attrs()  # Print global attributes for debugging
         p1 = pyproj.CRS(
             "proj=lcc lon_0=120.0 lat_0=21.494176864624023 lat_1=10.0 lat_2=40.0 a=6371229 b=6371229"
         )
@@ -665,8 +338,23 @@ class RWRF:
         # Start with getting grid bounds based on lat / lon box (SW-NW-NE-SE)
         # Ground-truth corner coordinates from the RWRF dataset [SW, NW, NE, SE]
         # Extracted from the provided XLAT and XLONG variables.
-        lat = np.array([19.548283, 27.897097, 27.844585, 19.49942])
-        lon = np.array([116.37149, 116.11554, 125.56778, 125.20111])
+        # RWRF().get_lat_lon_bound()  # Print lat/lon bounds for debugging
+        lat = np.array(
+            [
+                19.548282623291016,
+                27.897096633911133,
+                27.844585418701172,
+                19.499420166015625,
+            ]
+        )
+        lon = np.array(
+            [
+                116.37149047851562,
+                116.11553955078125,
+                125.56777954101562,
+                125.20111083984375,
+            ]
+        )
 
         # Transform lat/lon corners to projected easting/northing coordinates
         easting, northing = transformer.transform(lat, lon)
@@ -680,6 +368,36 @@ class RWRF:
         lat, lon = itransformer.transform(E, N)  # Transform the projected grid back
         lon = np.where(lon < 0, lon + 360, lon)
         return lat, lon
+
+    @classmethod
+    def get_corresponding_indices(
+        cls, latitude: float, longitude: float, resolution: tuple[int, int] = (32, 32)
+    ) -> tuple[int, int, int, int]:
+        """Get the corresponding indices for the given latitude and longitude.
+
+        Parameters
+        ----------
+        latitude : float
+            Latitude of the point.
+        longitude : float
+            Longitude of the point.
+
+        Returns
+        -------
+        tuple[int, int, int, int]
+            A tuple containing the minimum and maximum indices for corresponding latitude and longitude in the RWRF grid.
+        """
+
+        rwrf_lat, rwrf_lon = cls.grid()
+
+        dist = np.sqrt((rwrf_lat - latitude) ** 2 + (rwrf_lon - longitude) ** 2)
+        y_index, x_index = np.unravel_index(np.argmin(dist), dist.shape)
+        return (
+            y_index - resolution[0] // 2,
+            y_index + resolution[0] // 2,
+            x_index - resolution[1] // 2,
+            x_index + resolution[1] // 2,
+        )
 
     @classmethod
     def available(

--- a/earth2studio/data/rwrf.py
+++ b/earth2studio/data/rwrf.py
@@ -178,7 +178,7 @@ class RWRF:
 
             self._history_range = _range
         else:
-            raise ValueError(f"Invalid HRRR source { self._source}")
+            raise ValueError(f"Invalid HRRR source {self._source}")
 
         try:
             nest_asyncio.apply()  # Monkey patch asyncio to work in notebooks
@@ -299,7 +299,7 @@ class RWRF:
             session = None
 
         # Generate RWRF lat-lon grid to append onto data array
-        lat, lon = self.grid() #? fix this grid coordinates
+        lat, lon = self.grid()
         # Note, this could be more memory efficient and avoid pre-allocation of the array
         # but this is much much cleaner to deal with
         xr_array = xr.DataArray(
@@ -323,10 +323,10 @@ class RWRF:
                 "lon": (("rwrf_y", "rwrf_x"), lon),
             },
         )
-        
+
         date_str = "2019/08/03"
         hr_str = str(0).zfill(2)
-        
+
         dt = datetime.strptime(date_str, "%Y/%m/%d")
         fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
         folder = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
@@ -336,13 +336,13 @@ class RWRF:
             raise FileNotFoundError(f"File not found: {filepath}")
 
         ds = xr.open_dataset(filepath)
-        
+
         var_map = {
             "t2m": "T2",
             "u10m": "umet10",
             # add any others here...
         }
-        
+
         # # Loop through each requested variable and fill the xr_array
         for j, var in enumerate(variable):
             # Check if the variable exists in the NetCDF file
@@ -352,8 +352,12 @@ class RWRF:
                 data_slice = ds.variables[var_map.get(var, var)].isel(Time=0).values
                 xr_array[0, 0, j, :, :] = data_slice
             else:
-                logger.warning(f"Variable '{var}' not found in {filepath}. Filling with random numbers.")
-                xr_array[0, 0, j, :, :] = np.random.rand(len(self.RWRF_Y), len(self.RWRF_X))
+                logger.warning(
+                    f"Variable '{var}' not found in {filepath}. Filling with random numbers."
+                )
+                xr_array[0, 0, j, :, :] = np.random.rand(
+                    len(self.RWRF_Y), len(self.RWRF_X)
+                )
 
         if not self._cache:
             shutil.rmtree(self.cache)
@@ -428,7 +432,7 @@ class RWRF:
                         # could do this better with templates, but this is single instance
                         if variable_name == "APCP":
                             hours = int(lt.total_seconds() // 3600)
-                            hrrr_key = f"{variable_name}::{level}::{hours-1:d}-{hours:d} hour acc fcst"
+                            hrrr_key = f"{variable_name}::{level}::{hours - 1:d}-{hours:d} hour acc fcst"
 
                     except KeyError as e:
                         logger.error(
@@ -634,14 +638,14 @@ class RWRF:
 
     @classmethod
     def grid(cls) -> tuple[np.array, np.array]:
-        """Generates the HRRR lambert conformal projection grid coordinates. Creates the
-        HRRR grid using single parallel lambert conformal mapping
+        """Generates the RWRF lambert conformal projection grid coordinates. Creates the
+        RWRF grid using single parallel lambert conformal mapping
 
         Note
         ----
-        For more information about the HRRR grid see:
+        For more information about the RWRF grid see:
 
-        - https://ntrs.nasa.gov/api/citations/20160009371/downloads/20160009371.pdf
+        - examples/09-1_stormcast_example.py:170
 
         Returns
         -------
@@ -652,7 +656,7 @@ class RWRF:
         # lat_1, lat_2 is the standard parallel
         # a, b is radius of globe 6371229
         p1 = pyproj.CRS(
-            "proj=lcc lon_0=121.75 lat_0=23.4 lat_1=22 lat_2=25 a=6371229 b=6371229"
+            "proj=lcc lon_0=120.0 lat_0=21.494176864624023 lat_1=10.0 lat_2=40.0 a=6371229 b=6371229"
         )
         p2 = pyproj.CRS("latlon")
         transformer = pyproj.Transformer.from_proj(p2, p1)
@@ -661,12 +665,8 @@ class RWRF:
         # Start with getting grid bounds based on lat / lon box (SW-NW-NE-SE)
         # Ground-truth corner coordinates from the RWRF dataset [SW, NW, NE, SE]
         # Extracted from the provided XLAT and XLONG variables.
-        lat = np.array(
-            [19.548283, 27.897097, 27.844585, 19.49942]
-        )
-        lon = np.array(
-            [116.37149, 116.11554, 125.56778, 125.20111]
-        )
+        lat = np.array([19.548283, 27.897097, 27.844585, 19.49942])
+        lon = np.array([116.37149, 116.11554, 125.56778, 125.20111])
 
         # Transform lat/lon corners to projected easting/northing coordinates
         easting, northing = transformer.transform(lat, lon)
@@ -677,7 +677,7 @@ class RWRF:
             np.linspace(northing[0], northing[1], ny),
         )
 
-        lat, lon = itransformer.transform(E, N) # Transform the projected grid back
+        lat, lon = itransformer.transform(E, N)  # Transform the projected grid back
         lon = np.where(lon < 0, lon + 360, lon)
         return lat, lon
 

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -111,7 +111,7 @@ def fetch_data(
 
         da = xr.concat(da, "lead_time")
 
-    logger.debug(f"da {source.__class__.__name__} summary:")
+    logger.debug(f"{source.__class__.__name__} summary:")
     logger.debug(da)
 
     return prep_data_array(
@@ -152,9 +152,6 @@ def prep_data_array(
         Tuple containing output tensor and coordinate OrderedDict
     """
 
-    logger.info(
-        f"Using {interp_method} interpolation method to interpolate to {interp_to}"
-    )
     # Initialize the output CoordSystem
     out_coords = OrderedDict()
     for dim in da.coords.dims:

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -152,7 +152,9 @@ def prep_data_array(
         Tuple containing output tensor and coordinate OrderedDict
     """
 
-    logger.info(f"Using {interp_method} interpolation method to interpolate to {interp_to}")
+    logger.info(
+        f"Using {interp_method} interpolation method to interpolate to {interp_to}"
+    )
     # Initialize the output CoordSystem
     out_coords = OrderedDict()
     for dim in da.coords.dims:

--- a/earth2studio/data/utils.py
+++ b/earth2studio/data/utils.py
@@ -111,6 +111,9 @@ def fetch_data(
 
         da = xr.concat(da, "lead_time")
 
+    logger.debug(f"da {source.__class__.__name__} summary:")
+    logger.debug(da)
+
     return prep_data_array(
         da,
         device=device,
@@ -149,6 +152,7 @@ def prep_data_array(
         Tuple containing output tensor and coordinate OrderedDict
     """
 
+    logger.info(f"Using {interp_method} interpolation method to interpolate to {interp_to}")
     # Initialize the output CoordSystem
     out_coords = OrderedDict()
     for dim in da.coords.dims:

--- a/earth2studio/models/auto/package.py
+++ b/earth2studio/models/auto/package.py
@@ -170,6 +170,9 @@ class Package:
             self.cache_options["expiry_time"] = 31622400  # 1 year
 
         self.root = root
+        logger.info(
+            f"Initializing Package with root: {self.root}, cache: {cache}, cache_options: {self.cache_options}"
+        )
 
         if fs is not None:
             self.fs = fs

--- a/earth2studio/models/auto/package.py
+++ b/earth2studio/models/auto/package.py
@@ -282,8 +282,12 @@ class Package:
         io.BufferedReader
             Opened file, can get file path with BufferedReader.name
         """
-        full_path = os.path.join(self.root, file_path)
+        if file_path.startswith("/home/"):
+            full_path = file_path
+        else:
+            full_path = os.path.join(self.root, file_path)
         filename = os.path.basename(full_path)
+        logger.info(f"Opening file {filename} at {full_path} from {file_path}")
 
         with TqdmCallbackRelative(
             tqdm_kwargs={

--- a/earth2studio/models/px/__init__.py
+++ b/earth2studio/models/px/__init__.py
@@ -30,7 +30,7 @@ from earth2studio.models.px.interpmodafno import InterpModAFNO
 from earth2studio.models.px.pangu import Pangu3, Pangu6, Pangu24
 from earth2studio.models.px.persistence import Persistence
 from earth2studio.models.px.sfno import SFNO
-from earth2studio.models.px.stormcast import StormCast
+from earth2studio.models.px.stormcast import StormCast, StormCastTaiwan
 
 # TODO: Remove upon physics-nemo update...
 # package turned on logging of warnings in 1.1.0, this is silencing them

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -534,11 +534,9 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
     invariants : torch.Tensor
         Static invariant  quantities
     rwrf_lat_lim : tuple[int, int], optional
-        RWRF grid latitude limits, defaults to be the StormCastV1 region in central
-        United States, by default (273, 785)
+        RWRF grid latitude limits, defaults to be the StormCast region around National Taiwan University (25.0173° N, 121.5398° E), which corresponds to indices (295, 234) on the RWRF grid, by default (279, 311)
     rwrf_lon_lim : tuple[int, int], optional
-        RWRF grid longitude limits, defaults to be the StormCastV1 region in central
-        United States,, by default (579, 1219)
+        RWRF grid longitude limits, defaults to be the StormCast region around National Taiwan University (25.0173° N, 121.5398° E), which corresponds to indices (295, 234) on the RWRF grid, by default (218, 250)
     variables : np.array, optional
         High-resolution variables, by default np.array(VARIABLES)
     conditioning_means : torch.Tensor | None, optional
@@ -560,8 +558,8 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         means: torch.Tensor,
         stds: torch.Tensor,
         invariants: torch.Tensor,
-        rwrf_lat_lim: tuple[int, int] = (15, 47),
-        rwrf_lon_lim: tuple[int, int] = (110, 142),
+        rwrf_lat_lim: tuple[int, int] = (279, 311),
+        rwrf_lon_lim: tuple[int, int] = (218, 250),
         variables: np.array = np.array(VARIABLES),
         conditioning_means: torch.Tensor | None = None,
         conditioning_stds: torch.Tensor | None = None,
@@ -578,6 +576,22 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         self.sampler_args = sampler_args
 
         rwrf_lat, rwrf_lon = RWRF.grid()
+        # lat_min, lat_max = 21, 25
+        # lon_min, lon_max = 121, 125
+
+        # y_indices, x_indices = np.where(
+        #     (rwrf_lat >= lat_min)
+        #     & (rwrf_lat <= lat_max)
+        #     & (rwrf_lon >= lon_min)
+        #     & (rwrf_lon <= lon_max)
+        # )
+        # # Get min/max for slicing
+        # y_min, y_max = y_indices.min(), y_indices.max()
+        # x_min, x_max = x_indices.min(), x_indices.max()
+        # print("y_min, y_max, x_min, x_max", y_min, y_max, x_min, x_max)
+        # import sys
+
+        # sys.exit(0)
         self.lat = rwrf_lat[
             rwrf_lat_lim[0] : rwrf_lat_lim[1], rwrf_lon_lim[0] : rwrf_lon_lim[1]
         ]

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -724,6 +724,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         metadata = create_dummy_metadata(
             variable=["t2m"],
             conditioning_variable=["t2m"],
+            invariant=[],
             variable_file_path="/home/master/14/andrewhsu/projects/physicsnemo/dev/data/HighRes/stats/",
             conditioning_variable_file_path="/home/master/14/andrewhsu/projects/physicsnemo/dev/data/LowRes/stats/",
         )
@@ -813,8 +814,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         print(f"shape of out: {out.shape}")
 
         # Concat for diffusion conditioning
-        # condition = torch.cat((x, out, invariant_tensor), dim=1)
-        condition = torch.cat((x, out), dim=1)
+        condition = torch.cat((x, out, invariant_tensor), dim=1)
         print(f"shape of condition: {condition.shape}")
         latents = torch.randn_like(x)
         print(f"shape of latents: {latents.shape}")

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -24,7 +24,7 @@ import torch
 import xarray as xr
 import zarr
 
-from earth2studio.data import GFS_FX, HRRR, DataSource, ForecastSource, fetch_data
+from earth2studio.data import GFS_FX, HRRR, RWRF, DataSource, ForecastSource, fetch_data
 from earth2studio.models.auto import AutoModelMixin, Package
 from earth2studio.models.batch import batch_coords, batch_func
 from earth2studio.models.dx.base import DiagnosticModel
@@ -292,9 +292,29 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # Load metadata: means, stds, grid
         store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
         metadata = xr.open_zarr(store, zarr_format=2)
+        
+        # print("data", metadata)
+        # prints
+        # data <xarray.Dataset> Size: 5MB
+        # Dimensions:                (conditioning_variable: 26, invariant: 2, y: 512,
+        #                             x: 640, variable: 99)
+        # Coordinates:
+        #   * conditioning_variable  (conditioning_variable) <U5 520B 'u10m' ... 'q250'
+        #   * invariant              (invariant) <U9 72B 'lsm' 'orography'
+        #     lat                    (y, x) float32 1MB dask.array<chunksize=(256, 320), meta=np.ndarray>
+        #     lon                    (y, x) float32 1MB dask.array<chunksize=(256, 320), meta=np.ndarray>
+        #   * variable               (variable) <U5 2kB 'u10m' 'v10m' ... 'p20hl' 'refc'
+        #   * x                      (x) int64 5kB 0 1 2 3 4 5 ... 634 635 636 637 638 639
+        #   * y                      (y) int64 4kB 0 1 2 3 4 5 ... 506 507 508 509 510 511
+        # Data variables:
+        #     conditioning_means     (conditioning_variable) float32 104B dask.array<chunksize=(26,), meta=np.ndarray>
+        #     conditioning_stds      (conditioning_variable) float32 104B dask.array<chunksize=(26,), meta=np.ndarray>
+        #     invariants             (invariant, y, x) float32 3MB dask.array<chunksize=(1, 256, 320), meta=np.ndarray>
+        #     means                  (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
+        #     stds                   (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
 
         variables = metadata["variable"].values
-        conditioning_variables = metadata["conditioning_variable"].values
+        conditioning_variables = metadata["conditioning_variable"].values #? what's conditioning variable?
 
         # Expand dims and tensorify normalization buffers
         means = torch.from_numpy(metadata["means"].values[None, :, None, None])
@@ -307,7 +327,7 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
         # Load invariants
-        invariants = metadata["invariants"].sel(invariant=config.data.invariants).values
+        invariants = metadata["invariants"].sel(invariant=config.data.invariants).values #? what's invariant?
         invariants = torch.from_numpy(invariants).repeat(1, 1, 1, 1)
 
         # EDM sampler arguments
@@ -418,6 +438,426 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # TODO: ugh the interp... have to deal with this for now, no solution
         # handshake_coords(conditioning_coords, coords, "hrrr_x")
         # handshake_coords(conditioning_coords, coords, "hrrr_y")
+        handshake_coords(conditioning_coords, coords, "lead_time")
+        handshake_coords(conditioning_coords, coords, "time")
+
+        output_coords = self.output_coords(coords)
+
+        for i, _ in enumerate(coords["batch"]):
+            for j, _ in enumerate(coords["time"]):
+                for k, _ in enumerate(coords["lead_time"]):
+                    x[i, j, k : k + 1] = self._forward(
+                        x[i, j, k : k + 1], conditioning[i, j, k : k + 1]
+                    )
+
+        return x, output_coords
+
+    @batch_func()
+    def _default_generator(
+        self,
+        x: torch.Tensor,
+        coords: CoordSystem,
+    ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
+
+        coords = coords.copy()
+        self.output_coords(coords)
+        yield x, coords
+
+        if self.conditioning_data_source is None:
+            raise ValueError(
+                "A conditioning data source must be available for the iterator to function."
+            )
+
+        while True:
+            # Front hook
+            x, coords = self.front_hook(x, coords)
+            # Forward
+            x, coords = self.__call__(x, coords)
+            # Rear hook
+            x, coords = self.rear_hook(x, coords)
+            yield x, coords.copy()
+
+    def create_iterator(
+        self, x: torch.Tensor, coords: CoordSystem
+    ) -> Iterator[tuple[torch.Tensor, CoordSystem]]:
+        """Creates a iterator which can be used to perform time-integration of the
+        prognostic model. Will return the initial condition first (0th step).
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor
+        coords : CoordSystem
+            Input coordinate system
+
+        Yields
+        ------
+        Iterator[tuple[torch.Tensor, CoordSystem]]
+            Iterator that generates time-steps of the prognostic model container the
+            output data tensor and coordinate system dictionary.
+        """
+        yield from self._default_generator(x, coords)
+
+
+@check_optional_dependencies()
+class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
+    """StormCast generative convection-allowing model for regional forecasts consists of
+    two core models: a regression and diffusion model. Model time step size is 1 hour,
+    taking as input:
+
+    - High-resolution (3km) RWRF state over the central United States (99 vars)
+    - High-resolution land-sea mask and orography invariants
+    - Coarse resolution (25km) global state (26 vars)
+
+    The high-resolution grid is the RWRF Lambert conformal projection
+    Coarse-resolution inputs are regridded to the RWRF grid internally.
+
+    Note
+    ----
+    For more information see the following references:
+
+    - https://arxiv.org/abs/2408.10958
+
+    Parameters
+    ----------
+    regression_model : torch.nn.Module
+        Deterministic model used to make an initial prediction
+    diffusion_model : torch.nn.Module
+        Generative model correcting the deterministic prediciton
+    means : torch.Tensor
+        Mean value of each input high-resolution variable
+    stds : torch.Tensor
+        Standard deviation of each input high-resolution variable
+    invariants : torch.Tensor
+        Static invariant  quantities
+    rwrf_lat_lim : tuple[int, int], optional
+        RWRF grid latitude limits, defaults to be the StormCastV1 region in central
+        United States, by default (273, 785)
+    rwrf_lon_lim : tuple[int, int], optional
+        RWRF grid longitude limits, defaults to be the StormCastV1 region in central
+        United States,, by default (579, 1219)
+    variables : np.array, optional
+        High-resolution variables, by default np.array(VARIABLES)
+    conditioning_means : torch.Tensor | None, optional
+        Means to normalize conditioning data, by default None
+    conditioning_stds : torch.Tensor | None, optional
+        Standard deviations to normalize conditioning data, by default None
+    conditioning_variables : np.array, optional
+        Global variables for conditioning, by default np.array(CONDITIONING_VARIABLES)
+    conditioning_data_source : DataSource | ForecastSource | None, optional
+        Data Source to use for global conditioning. Required for running in iterator mode, by default None
+    sampler_args : dict[str, float  |  int], optional
+        Arguments to pass to the diffusion sampler, by default {}
+    """
+
+    def __init__(
+        self,
+        regression_model: torch.nn.Module,
+        diffusion_model: torch.nn.Module,
+        means: torch.Tensor,
+        stds: torch.Tensor,
+        invariants: torch.Tensor,
+        rwrf_lat_lim: tuple[int, int] = (21, 25),
+        rwrf_lon_lim: tuple[int, int] = (121, 125),
+        variables: np.array = np.array(VARIABLES),
+        conditioning_means: torch.Tensor | None = None,
+        conditioning_stds: torch.Tensor | None = None,
+        conditioning_variables: np.array = np.array(CONDITIONING_VARIABLES),
+        conditioning_data_source: DataSource | ForecastSource | None = None,
+        sampler_args: dict[str, float | int] = {},
+    ):
+        super().__init__()
+        self.regression_model = regression_model
+        self.diffusion_model = diffusion_model
+        self.register_buffer("means", means)
+        self.register_buffer("stds", stds)
+        self.register_buffer("invariants", invariants)
+        self.sampler_args = sampler_args
+
+        rwrf_lat, rwrf_lon = RWRF.grid() #? fix this grid coordinates as well
+        self.lat = rwrf_lat[
+            rwrf_lat_lim[0] : rwrf_lat_lim[1], rwrf_lon_lim[0] : rwrf_lon_lim[1]
+        ]
+        self.lon = rwrf_lon[
+            rwrf_lat_lim[0] : rwrf_lat_lim[1], rwrf_lon_lim[0] : rwrf_lon_lim[1]
+        ]
+
+        self.rwrf_x = np.arange(rwrf_lon_lim[0], rwrf_lon_lim[1], 1)
+        self.rwrf_y = np.arange(rwrf_lat_lim[0], rwrf_lat_lim[1], 1)
+
+        self.variables = variables
+
+        self.conditioning_variables = conditioning_variables
+        self.conditioning_data_source = conditioning_data_source
+        if conditioning_data_source is None:
+            warnings.warn(
+                "No conditioning data source was provided to StormCast, "
+                + "set the conditioning_data_source attribute of the model "
+                + "before running inference."
+            )
+
+        if conditioning_means is not None:
+            self.register_buffer("conditioning_means", conditioning_means)
+
+        if conditioning_stds is not None:
+            self.register_buffer("conditioning_stds", conditioning_stds)
+
+    def input_coords(self) -> CoordSystem:
+        """Input coordinate system"""
+        return OrderedDict(
+            {
+                "batch": np.empty(0),
+                "time": np.empty(0),
+                "lead_time": np.array([np.timedelta64(0, "h")]),
+                "variable": np.array(self.variables),
+                "rwrf_y": self.rwrf_y,
+                "rwrf_x": self.rwrf_x,
+            }
+        )
+
+    @batch_coords()
+    def output_coords(self, input_coords: CoordSystem) -> CoordSystem:
+        """Output coordinate system of diagnostic model
+
+        Parameters
+        ----------
+        input_coords : CoordSystem
+            Input coordinate system to transform into output_coords
+            by default None, will use self.input_coords.
+
+        Returns
+        -------
+        CoordSystem
+            Coordinate system dictionary
+        """
+
+        output_coords = OrderedDict(
+            {
+                "batch": np.empty(0),
+                "time": np.empty(0),
+                "lead_time": np.array([np.timedelta64(1, "h")]),
+                "variable": np.array(self.variables),
+                "rwrf_y": self.rwrf_y,
+                "rwrf_x": self.rwrf_x,
+            }
+        )
+
+        target_input_coords = self.input_coords()
+
+        handshake_dim(input_coords, "rwrf_x", 5)
+        handshake_dim(input_coords, "rwrf_y", 4)
+        handshake_dim(input_coords, "variable", 3)
+        handshake_coords(input_coords, target_input_coords, "rwrf_x")
+        handshake_coords(input_coords, target_input_coords, "rwrf_y")
+        handshake_coords(input_coords, target_input_coords, "variable")
+
+        output_coords["batch"] = input_coords["batch"]
+        output_coords["time"] = input_coords["time"]
+        output_coords["lead_time"] = (
+            output_coords["lead_time"] + input_coords["lead_time"]
+        )
+        return output_coords
+
+    @classmethod
+    def load_default_package(cls) -> Package:
+        """Load prognostic package"""
+        package = Package(
+            "/home/master/13/dczy/stormcast-v1-era5-hrrr_v1.0.1",
+            # "/home/master/13/dczy/awerawe",
+            cache=False,
+            # cache_options={
+            #     "cache_storage": Package.default_cache("stormcast"),
+            #     "same_names": True,
+            # },
+        )
+        return package
+
+    @classmethod
+    @check_optional_dependencies()
+    def load_model(
+        cls,
+        package: Package,
+        conditioning_data_source: DataSource | ForecastSource = GFS_FX(),
+    ) -> DiagnosticModel:
+        """Load prognostic from package
+
+        Parameters
+        ----------
+        package : Package
+            Package to load model from
+        conditioning_data_source : DataSource | ForecastSource, optional
+            Data source to use for global conditioning, by default GFS_FX
+
+        Returns
+        -------
+        PrognosticModel
+            Prognostic model
+        """
+        try:
+            OmegaConf.register_new_resolver("eval", eval)
+        except ValueError:
+            # Likely already registered so skip
+            pass
+
+        # load model registry:
+        config = OmegaConf.load(package.resolve("model.yaml"))
+
+        regression = PhysicsNemoModule.from_checkpoint(
+            package.resolve("StormCastUNet.0.0.mdlus")
+        )
+        diffusion = PhysicsNemoModule.from_checkpoint(
+            package.resolve("EDMPrecond.0.0.mdlus")
+        )
+
+        # Load metadata: means, stds, grid
+        store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
+        metadata = xr.open_zarr(store, zarr_format=2)
+        
+        # print("data", metadata)
+        # prints
+        # data <xarray.Dataset> Size: 5MB
+        # Dimensions:                (conditioning_variable: 26, invariant: 2, y: 512,
+        #                             x: 640, variable: 99)
+        # Coordinates:
+        #   * conditioning_variable  (conditioning_variable) <U5 520B 'u10m' ... 'q250'
+        #   * invariant              (invariant) <U9 72B 'lsm' 'orography'
+        #     lat                    (y, x) float32 1MB dask.array<chunksize=(256, 320), meta=np.ndarray>
+        #     lon                    (y, x) float32 1MB dask.array<chunksize=(256, 320), meta=np.ndarray>
+        #   * variable               (variable) <U5 2kB 'u10m' 'v10m' ... 'p20hl' 'refc'
+        #   * x                      (x) int64 5kB 0 1 2 3 4 5 ... 634 635 636 637 638 639
+        #   * y                      (y) int64 4kB 0 1 2 3 4 5 ... 506 507 508 509 510 511
+        # Data variables:
+        #     conditioning_means     (conditioning_variable) float32 104B dask.array<chunksize=(26,), meta=np.ndarray>
+        #     conditioning_stds      (conditioning_variable) float32 104B dask.array<chunksize=(26,), meta=np.ndarray>
+        #     invariants             (invariant, y, x) float32 3MB dask.array<chunksize=(1, 256, 320), meta=np.ndarray>
+        #     means                  (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
+        #     stds                   (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
+
+        variables = metadata["variable"].values
+        conditioning_variables = metadata["conditioning_variable"].values #? what's conditioning variable?
+
+        # Expand dims and tensorify normalization buffers
+        means = torch.from_numpy(metadata["means"].values[None, :, None, None])
+        stds = torch.from_numpy(metadata["stds"].values[None, :, None, None])
+        conditioning_means = torch.from_numpy(
+            metadata["conditioning_means"].values[None, :, None, None]
+        )
+        conditioning_stds = torch.from_numpy(
+            metadata["conditioning_stds"].values[None, :, None, None]
+        )
+
+        # Load invariants
+        invariants = metadata["invariants"].sel(invariant=config.data.invariants).values #? what's invariant?
+        invariants = torch.from_numpy(invariants).repeat(1, 1, 1, 1)
+
+        # EDM sampler arguments
+        if config.sampler_args is not None:
+            sampler_args = config.sampler_args
+        else:
+            sampler_args = {}
+
+        return cls(
+            regression,
+            diffusion,
+            means,
+            stds,
+            invariants,
+            variables=variables,
+            conditioning_means=conditioning_means,
+            conditioning_stds=conditioning_stds,
+            conditioning_data_source=conditioning_data_source,
+            conditioning_variables=conditioning_variables,
+            sampler_args=sampler_args,
+        )
+
+    @torch.inference_mode()
+    def _forward(self, x: torch.Tensor, conditioning: torch.Tensor) -> torch.Tensor:
+
+        # Scale data
+        if "conditioning_means" in self._buffers:
+            conditioning = conditioning - self.conditioning_means
+        if "conditioning_stds" in self._buffers:
+            conditioning = conditioning / self.conditioning_stds
+
+        x = (x - self.means) / self.stds
+
+        # Run regression model
+        invariant_tensor = self.invariants.repeat(x.shape[0], 1, 1, 1)
+        concats = torch.cat((x, conditioning, invariant_tensor), dim=1)
+
+        out = self.regression_model(concats)
+
+        # Concat for diffusion conditioning
+        condition = torch.cat((x, out, invariant_tensor), dim=1)
+        latents = torch.randn_like(x)
+
+        # Run diffusion model
+        edm_out = deterministic_sampler(
+            self.diffusion_model,
+            latents=latents,
+            img_lr=condition,
+            **self.sampler_args,
+        )
+
+        out += edm_out
+
+        out = out * self.stds + self.means
+
+        return out
+
+    @torch.inference_mode()
+    @batch_func()
+    def __call__(
+        self,
+        x: torch.Tensor,
+        coords: CoordSystem,
+    ) -> tuple[torch.Tensor, CoordSystem]:
+        """Runs prognostic model 1 step
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor
+        coords : CoordSystem
+            Input coordinate system
+
+        Returns
+        -------
+        tuple[torch.Tensor, CoordSystem]
+            Output tensor and coordinate system
+
+        Raises
+        ------
+        RuntimeError
+            If conditioning data source is not initialized
+        """
+
+        if self.conditioning_data_source is None:
+            raise RuntimeError(
+                "StormCast has been called without initializing the model's conditioning_data_source"
+            )
+
+        # TODO: Eventually pull out interpolation into model and remove it from fetch
+        # data potentially
+        conditioning, conditioning_coords = fetch_data(
+            self.conditioning_data_source,
+            time=coords["time"],
+            variable=self.conditioning_variables,
+            lead_time=coords["lead_time"],
+            device=x.device,
+            interp_to=coords | {"_lat": self.lat, "_lon": self.lon},
+            interp_method="linear",
+        )
+
+        # Add a batch dim
+        conditioning = conditioning.repeat(x.shape[0], 1, 1, 1, 1, 1)
+        conditioning_coords.update({"batch": np.empty(0)})
+        conditioning_coords.move_to_end("batch", last=False)
+
+        # Handshake conditioning coords
+        # TODO: ugh the interp... have to deal with this for now, no solution
+        # handshake_coords(conditioning_coords, coords, "rwrf_x")
+        # handshake_coords(conditioning_coords, coords, "rwrf_y")
         handshake_coords(conditioning_coords, coords, "lead_time")
         handshake_coords(conditioning_coords, coords, "time")
 

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -721,7 +721,9 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # Load metadata: means, stds, grid
         # store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
         # metadata = xr.open_zarr(store, zarr_format=2)
-        metadata = create_dummy_metadata(variable=["t2m"])
+        metadata = create_dummy_metadata(
+            variable=["t2m"], conditioning_variable=["t2m"]
+        )
 
         print("data", metadata)
         # prints
@@ -780,7 +782,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
             variables=variables,
             conditioning_means=conditioning_means,
             conditioning_stds=conditioning_stds,
-            conditioning_data_source=conditioning_data_source,
+            conditioning_data_source=conditioning_data_source,  #!  use ERA5 to replay/reconstruct past events, use GFS_FX for forecasting
             conditioning_variables=conditioning_variables,
             sampler_args=sampler_args,
         )

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -37,7 +37,7 @@ from earth2studio.utils.imports import (
     OptionalDependencyFailure,
     check_optional_dependencies,
 )
-from earth2studio.utils.metadata import create_dummy_metadata
+from earth2studio.utils.metadata import create_metadata
 from earth2studio.utils.type import CoordSystem
 
 try:
@@ -558,8 +558,8 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         means: torch.Tensor,
         stds: torch.Tensor,
         invariants: torch.Tensor,
-        rwrf_lat_lim: tuple[int, int] = (279, 311),
-        rwrf_lon_lim: tuple[int, int] = (218, 250),
+        rwrf_lat_lim: tuple[int, int] = (276, 308),
+        rwrf_lon_lim: tuple[int, int] = (243, 275),
         variables: np.array = np.array(VARIABLES),
         conditioning_means: torch.Tensor | None = None,
         conditioning_stds: torch.Tensor | None = None,
@@ -576,22 +576,6 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         self.sampler_args = sampler_args
 
         rwrf_lat, rwrf_lon = RWRF.grid()
-        # lat_min, lat_max = 21, 25
-        # lon_min, lon_max = 121, 125
-
-        # y_indices, x_indices = np.where(
-        #     (rwrf_lat >= lat_min)
-        #     & (rwrf_lat <= lat_max)
-        #     & (rwrf_lon >= lon_min)
-        #     & (rwrf_lon <= lon_max)
-        # )
-        # # Get min/max for slicing
-        # y_min, y_max = y_indices.min(), y_indices.max()
-        # x_min, x_max = x_indices.min(), x_indices.max()
-        # print("y_min, y_max, x_min, x_max", y_min, y_max, x_min, x_max)
-        # import sys
-
-        # sys.exit(0)
         self.lat = rwrf_lat[
             rwrf_lat_lim[0] : rwrf_lat_lim[1], rwrf_lon_lim[0] : rwrf_lon_lim[1]
         ]
@@ -680,12 +664,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         """Load prognostic package"""
         package = Package(
             "/home/master/13/dczy/stormcast-v1-era5-hrrr_v1.0.1",
-            # "/home/master/13/dczy/awerawe",
             cache=False,
-            # cache_options={
-            #     "cache_storage": Package.default_cache("stormcast"),
-            #     "same_names": True,
-            # },
         )
         return package
 
@@ -735,7 +714,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # Load metadata: means, stds, grid
         # store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
         # metadata = xr.open_zarr(store, zarr_format=2)
-        metadata = create_dummy_metadata(
+        metadata = create_metadata(
             variable=["t2m"],
             conditioning_variable=["t2m"],
             invariant=[],
@@ -744,7 +723,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
         print("data", metadata)
-        # prints
+        # Original Metadata prints
         # data <xarray.Dataset> Size: 5MB
         # Dimensions:                (conditioning_variable: 26, invariant: 2, y: 512,
         #                             x: 640, variable: 99)

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -701,13 +701,13 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         regression = PhysicsNemoModule.from_checkpoint(
             # package.resolve("StormCastUNet.0.0.mdlus")
             package.resolve(
-                "/home/master/14/andrewhsu/projects/earth2studio/cache/rundir_reg_0710_24hrs/stormcast-training/0/checkpoints_regression/StormCastUNet.0.16000.mdlus"
+                "/home/master/14/andrewhsu/projects/earth2studio/checkpoints/rundir_reg_0710_24hrs/stormcast-training/0/checkpoints_regression/StormCastUNet.0.16000.mdlus"
             )
         )
         diffusion = PhysicsNemoModule.from_checkpoint(
             # package.resolve("EDMPrecond.0.0.mdlus")
             package.resolve(
-                "/home/master/14/andrewhsu/projects/earth2studio/cache/rundir_dif_0710_24hrs/diffusion/0/checkpoints_diffusion/EDMPrecond.0.16000.mdlus"
+                "/home/master/14/andrewhsu/projects/earth2studio/checkpoints/rundir_dif_0710_24hrs/diffusion/0/checkpoints_diffusion/EDMPrecond.0.16000.mdlus"
             )
         )
 

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -722,7 +722,10 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
         # metadata = xr.open_zarr(store, zarr_format=2)
         metadata = create_dummy_metadata(
-            variable=["t2m"], conditioning_variable=["t2m"]
+            variable=["t2m"],
+            conditioning_variable=["t2m"],
+            variable_file_path="/home/master/14/andrewhsu/projects/physicsnemo/dev/data/HighRes/stats/",
+            conditioning_variable_file_path="/home/master/14/andrewhsu/projects/physicsnemo/dev/data/LowRes/stats/",
         )
 
         print("data", metadata)

--- a/earth2studio/models/px/stormcast.py
+++ b/earth2studio/models/px/stormcast.py
@@ -37,6 +37,7 @@ from earth2studio.utils.imports import (
     OptionalDependencyFailure,
     check_optional_dependencies,
 )
+from earth2studio.utils.metadata import create_dummy_metadata
 from earth2studio.utils.type import CoordSystem
 
 try:
@@ -292,7 +293,7 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         # Load metadata: means, stds, grid
         store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
         metadata = xr.open_zarr(store, zarr_format=2)
-        
+
         # print("data", metadata)
         # prints
         # data <xarray.Dataset> Size: 5MB
@@ -314,7 +315,9 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         #     stds                   (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
 
         variables = metadata["variable"].values
-        conditioning_variables = metadata["conditioning_variable"].values #? what's conditioning variable?
+        conditioning_variables = metadata[
+            "conditioning_variable"
+        ].values  # ? what's conditioning variable?
 
         # Expand dims and tensorify normalization buffers
         means = torch.from_numpy(metadata["means"].values[None, :, None, None])
@@ -327,7 +330,9 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
         # Load invariants
-        invariants = metadata["invariants"].sel(invariant=config.data.invariants).values #? what's invariant?
+        invariants = (
+            metadata["invariants"].sel(invariant=config.data.invariants).values
+        )  # ? what's invariant?
         invariants = torch.from_numpy(invariants).repeat(1, 1, 1, 1)
 
         # EDM sampler arguments
@@ -352,7 +357,6 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
     @torch.inference_mode()
     def _forward(self, x: torch.Tensor, conditioning: torch.Tensor) -> torch.Tensor:
-
         # Scale data
         if "conditioning_means" in self._buffers:
             conditioning = conditioning - self.conditioning_means
@@ -458,7 +462,6 @@ class StormCast(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         x: torch.Tensor,
         coords: CoordSystem,
     ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
-
         coords = coords.copy()
         self.output_coords(coords)
         yield x, coords
@@ -557,8 +560,8 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         means: torch.Tensor,
         stds: torch.Tensor,
         invariants: torch.Tensor,
-        rwrf_lat_lim: tuple[int, int] = (21, 25),
-        rwrf_lon_lim: tuple[int, int] = (121, 125),
+        rwrf_lat_lim: tuple[int, int] = (15, 47),
+        rwrf_lon_lim: tuple[int, int] = (110, 142),
         variables: np.array = np.array(VARIABLES),
         conditioning_means: torch.Tensor | None = None,
         conditioning_stds: torch.Tensor | None = None,
@@ -574,7 +577,7 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         self.register_buffer("invariants", invariants)
         self.sampler_args = sampler_args
 
-        rwrf_lat, rwrf_lon = RWRF.grid() #? fix this grid coordinates as well
+        rwrf_lat, rwrf_lon = RWRF.grid()
         self.lat = rwrf_lat[
             rwrf_lat_lim[0] : rwrf_lat_lim[1], rwrf_lon_lim[0] : rwrf_lon_lim[1]
         ]
@@ -703,17 +706,24 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         config = OmegaConf.load(package.resolve("model.yaml"))
 
         regression = PhysicsNemoModule.from_checkpoint(
-            package.resolve("StormCastUNet.0.0.mdlus")
+            # package.resolve("StormCastUNet.0.0.mdlus")
+            package.resolve(
+                "/home/master/14/andrewhsu/projects/earth2studio/cache/rundir_reg_0710_24hrs/stormcast-training/0/checkpoints_regression/StormCastUNet.0.16000.mdlus"
+            )
         )
         diffusion = PhysicsNemoModule.from_checkpoint(
-            package.resolve("EDMPrecond.0.0.mdlus")
+            # package.resolve("EDMPrecond.0.0.mdlus")
+            package.resolve(
+                "/home/master/14/andrewhsu/projects/earth2studio/cache/rundir_dif_0710_24hrs/diffusion/0/checkpoints_diffusion/EDMPrecond.0.16000.mdlus"
+            )
         )
 
         # Load metadata: means, stds, grid
-        store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
-        metadata = xr.open_zarr(store, zarr_format=2)
-        
-        # print("data", metadata)
+        # store = zarr.storage.ZipStore(package.resolve("metadata.zarr.zip"), mode="r")
+        # metadata = xr.open_zarr(store, zarr_format=2)
+        metadata = create_dummy_metadata(variable=["t2m"])
+
+        print("data", metadata)
         # prints
         # data <xarray.Dataset> Size: 5MB
         # Dimensions:                (conditioning_variable: 26, invariant: 2, y: 512,
@@ -734,7 +744,9 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         #     stds                   (variable) float32 396B dask.array<chunksize=(99,), meta=np.ndarray>
 
         variables = metadata["variable"].values
-        conditioning_variables = metadata["conditioning_variable"].values #? what's conditioning variable?
+        conditioning_variables = metadata[
+            "conditioning_variable"
+        ].values  # ? what's conditioning variable?
 
         # Expand dims and tensorify normalization buffers
         means = torch.from_numpy(metadata["means"].values[None, :, None, None])
@@ -747,7 +759,10 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         )
 
         # Load invariants
-        invariants = metadata["invariants"].sel(invariant=config.data.invariants).values #? what's invariant?
+        # invariants = (
+        #     metadata["invariants"].sel(invariant=config.data.invariants).values
+        # )  # ? what's invariant?
+        invariants = metadata["invariants"].values
         invariants = torch.from_numpy(invariants).repeat(1, 1, 1, 1)
 
         # EDM sampler arguments
@@ -772,7 +787,6 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
 
     @torch.inference_mode()
     def _forward(self, x: torch.Tensor, conditioning: torch.Tensor) -> torch.Tensor:
-
         # Scale data
         if "conditioning_means" in self._buffers:
             conditioning = conditioning - self.conditioning_means
@@ -782,14 +796,23 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         x = (x - self.means) / self.stds
 
         # Run regression model
+        print(
+            f"\nshape of x: {x.shape}, conditioning: {conditioning.shape}, invariants: {self.invariants.shape}"
+        )
         invariant_tensor = self.invariants.repeat(x.shape[0], 1, 1, 1)
+        print(f"shape of invariant_tensor: {invariant_tensor.shape}")
         concats = torch.cat((x, conditioning, invariant_tensor), dim=1)
+        print(f"shape of concats: {concats.shape}")
 
         out = self.regression_model(concats)
+        print(f"shape of out: {out.shape}")
 
         # Concat for diffusion conditioning
-        condition = torch.cat((x, out, invariant_tensor), dim=1)
+        # condition = torch.cat((x, out, invariant_tensor), dim=1)
+        condition = torch.cat((x, out), dim=1)
+        print(f"shape of condition: {condition.shape}")
         latents = torch.randn_like(x)
+        print(f"shape of latents: {latents.shape}")
 
         # Run diffusion model
         edm_out = deterministic_sampler(
@@ -878,7 +901,6 @@ class StormCastTaiwan(torch.nn.Module, AutoModelMixin, PrognosticMixin):
         x: torch.Tensor,
         coords: CoordSystem,
     ) -> Generator[tuple[torch.Tensor, CoordSystem], None, None]:
-
         coords = coords.copy()
         self.output_coords(coords)
         yield x, coords

--- a/earth2studio/run.py
+++ b/earth2studio/run.py
@@ -86,7 +86,9 @@ def deterministic(
     prognostic_ic = prognostic.input_coords()
     time = to_time_array(time)
 
-    logger.info(f"{prognostic.__class__.__name__} has interpolation method: {hasattr(prognostic, "interp_method")}")
+    logger.info(
+        f"{prognostic.__class__.__name__} has interpolation method: {hasattr(prognostic, 'interp_method')}"
+    )
 
     if hasattr(prognostic, "interp_method"):
         interp_to = prognostic_ic
@@ -254,7 +256,6 @@ def diagnostic(
     logger.info("Inference starting!")
     with tqdm(total=nsteps + 1, desc="Running inference", position=1) as pbar:
         for step, (x, coords) in enumerate(model):
-
             # Run diagnostic
             x, coords = map_coords(x, coords, diagnostic_ic)
             x, coords = diagnostic(x, coords)
@@ -383,7 +384,6 @@ def ensemble(
         desc="Total Ensemble Batches",
         position=2,
     ):
-
         # Get fresh batch data
         x = x0.to(device)
 

--- a/earth2studio/run.py
+++ b/earth2studio/run.py
@@ -86,6 +86,8 @@ def deterministic(
     prognostic_ic = prognostic.input_coords()
     time = to_time_array(time)
 
+    logger.info(f"{prognostic.__class__.__name__} has interpolation method: {hasattr(prognostic, "interp_method")}")
+
     if hasattr(prognostic, "interp_method"):
         interp_to = prognostic_ic
         interp_method = prognostic.interp_method

--- a/earth2studio/run.py
+++ b/earth2studio/run.py
@@ -97,6 +97,10 @@ def deterministic(
         interp_to = None
         interp_method = "nearest"
 
+    logger.info(
+        f"Using {interp_method} interpolation method to interpolate to {interp_to}"
+    )
+
     x, coords = fetch_data(
         source=data,
         time=time,

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import xarray as xr
+
+from earth2studio.utils.type import VariableArray
+
+
+def create_dummy_metadata(
+    variable: str | list[str] | VariableArray,
+    conditioning_variable: str | list[str] | VariableArray = "",
+    invariant: str | list[str] | VariableArray = "c",
+    y: int = 32,
+    x: int = 32,
+) -> xr.Dataset:
+    """Creates a dummy metadata xarray dataset with a structure matching the StormCast model's metadata.
+
+    Parameters
+    ----------
+    variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to variables to
+        return. Must be in the HRRR lexicon.
+    conditioning_variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to conditioning variables to
+        return. Must be in the HRRR lexicon.
+    invariant : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to invariant to
+        return. Must be in the HRRR lexicon.
+    y : int
+        The number of latitude grid points.
+    x : int
+        The number of longitude grid points.
+
+    Returns
+    -------
+    xarray.Dataset
+        A dummy Stormcast metadata xarray dataset
+
+    """
+
+    if isinstance(variable, str):
+        variable = [variable]
+
+    if isinstance(conditioning_variable, str):
+        # conditioning_variable = [conditioning_variable]
+        conditioning_variable = []
+
+    if isinstance(invariant, str):
+        invariant = [invariant]
+
+    dims = {
+        "conditioning_variable": len(conditioning_variable),
+        "invariant": len(invariant),
+        "y": y,
+        "x": x,
+        "variable": len(variable),
+    }
+
+    coords = {
+        "conditioning_variable": conditioning_variable,
+        "invariant": invariant,
+        "lat": (
+            ("y", "x"),
+            np.random.rand(dims["y"], dims["x"]).astype(np.float32) * 90,
+        ),
+        "lon": (
+            ("y", "x"),
+            np.random.rand(dims["y"], dims["x"]).astype(np.float32) * 180,
+        ),
+        "variable": variable,
+        "x": np.arange(dims["x"]),
+        "y": np.arange(dims["y"]),
+    }
+
+    data_vars = {
+        "conditioning_means": (
+            ("conditioning_variable",),
+            np.random.rand(dims["conditioning_variable"]).astype(np.float32),
+        ),
+        "conditioning_stds": (
+            ("conditioning_variable",),
+            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1,
+        ),
+        "invariants": (
+            ("invariant", "y", "x"),
+            np.random.rand(dims["invariant"], dims["y"], dims["x"]).astype(np.float32),
+        ),
+        "means": (("variable",), np.random.rand(dims["variable"]).astype(np.float32)),
+        "stds": (
+            ("variable",),
+            np.random.rand(dims["variable"]).astype(np.float32) + 0.1,
+        ),
+    }
+
+    ds = xr.Dataset(data_vars=data_vars, coords=coords)
+
+    return ds

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -23,7 +23,7 @@ from earth2studio.utils.type import VariableArray
 def create_dummy_metadata(
     variable: str | list[str] | VariableArray,
     conditioning_variable: str | list[str] | VariableArray,
-    invariant: str | list[str] | VariableArray = [],
+    invariant: str | list[str] | VariableArray,
     y: int = 32,
     x: int = 32,
     variable_file_path: str | None = None,

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -27,7 +27,7 @@ def create_dummy_metadata(
     y: int = 32,
     x: int = 32,
     variable_file_path: str | None = None,
-    conditioning_file_path: str | None = None,
+    conditioning_variable_file_path: str | None = None,
     invariant_file_path: str | None = None,
 ) -> xr.Dataset:
     """Creates a StormCast metadata xarray dataset with a structure matching the StormCast model's metadata.
@@ -49,7 +49,7 @@ def create_dummy_metadata(
         The number of longitude grid points.
     variable_file_path : str | None
         Path to the file containing the variable std/mean. If None, the variable std/mean will be randomly generated.
-    conditioning_file_path : str | None
+    conditioning_variable_file_path : str | None
         Path to the file containing the conditioning variable std/mean. If None, the conditioning variable std/mean will be randomly generated.
     invariant_file_path : str | None
         Path to the file containing the invariant data. If None, the invariant data will be randomly generated.
@@ -95,24 +95,20 @@ def create_dummy_metadata(
     }
 
     if variable_file_path is not None:
-        variable_means = xr.open_dataarray(variable_file_path).values
-        variable_std = xr.open_dataarray(variable_file_path).values
+        variable_means = np.load(f"{variable_file_path}/means.npy")
+        variable_stds = np.load(f"{variable_file_path}/stds.npy")
     else:
-        variable_means = np.random.rand(dims["conditioning_variable"]).astype(
-            np.float32
-        )
-        variable_std = (
-            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1
-        )
+        variable_means = np.random.rand(dims["variable"]).astype(np.float32)
+        variable_stds = np.random.rand(dims["variable"]).astype(np.float32) + 0.1
 
-    if conditioning_file_path is not None:
-        conditioning_means = xr.open_dataarray(conditioning_file_path).values
-        conditioning_std = xr.open_dataarray(conditioning_file_path).values
+    if conditioning_variable_file_path is not None:
+        conditioning_means = np.load(f"{conditioning_variable_file_path}/means.npy")
+        conditioning_stds = np.load(f"{conditioning_variable_file_path}/stds.npy")
     else:
         conditioning_means = np.random.rand(dims["conditioning_variable"]).astype(
             np.float32
         )
-        conditioning_std = (
+        conditioning_stds = (
             np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1
         )
 
@@ -130,11 +126,11 @@ def create_dummy_metadata(
         ),
         "conditioning_stds": (
             ("conditioning_variable",),
-            conditioning_std,
+            conditioning_stds,
         ),
         "invariants": (("invariant", "y", "x"), invariant_data),
         "means": (("variable",), variable_means),
-        "stds": (("variable",), variable_std),
+        "stds": (("variable",), variable_stds),
     }
 
     ds = xr.Dataset(data_vars=data_vars, coords=coords)

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -20,89 +20,7 @@ import xarray as xr
 from earth2studio.utils.type import VariableArray
 
 
-def prep_metadata_inputs(
-    variable: str | list[str] | VariableArray,
-    conditioning_variable: str | list[str] | VariableArray,
-    invariant: str | list[str] | VariableArray,
-) -> tuple[list[str], list[str], list[str]]:
-    """Simple method to pre-process metadata inputs into a common form
-
-    Parameters
-    ----------
-    variable : str | list[str] | VariableArray
-        String, list of strings or array of strings that refer to variables
-    conditioning_variable : str | list[str] | VariableArray
-        String, list of strings or array of strings that refer to conditioning variables
-    invariant : str | list[str] | VariableArray
-        String, list of strings or array of strings that refer to invariant variables
-
-    Returns
-    -------
-    tuple[list[str], list[str], list[str]]
-        Variable, conditioning variable, and invariant lists
-    """
-    if isinstance(variable, str):
-        variable = [variable]
-
-    if isinstance(conditioning_variable, str):
-        conditioning_variable = [conditioning_variable]
-
-    if isinstance(invariant, str):
-        invariant = [invariant]
-
-    return variable, conditioning_variable, invariant
-
-
-def load_means_stds(
-    dims: tuple[int, ...], file_path: str | None
-) -> tuple[np.ndarray, np.ndarray]:
-    """Simple method to load means and standard deviations from .npy files or generate random numpy arrays.
-
-    Parameters
-    ----------
-    dims : tuple[int, ...]
-        Dimensions of the array to be loaded or generated.
-    file_path : str | None
-        Path to the directory containing the means and stds .npy files. If None, random data will be generated.
-
-    Returns
-    -------
-    tuple[np.ndarray, np.ndarray]
-        Tuple containing the means and standard deviations as numpy arrays.
-    """
-    if file_path is not None:
-        means = np.load(f"{file_path}/means.npy")
-        stds = np.load(f"{file_path}/stds.npy")
-    else:
-        means = np.random.rand(*dims).astype(np.float32)
-        stds = np.random.rand(*dims).astype(np.float32) + 0.1
-    return means, stds
-
-
-def load_invariant_data(dims: tuple[int, ...], file_path: str | None) -> np.ndarray:
-    """Simple method to load invariant data from zarr files or generate random numpy arrays.
-
-    Parameters
-    ----------
-    dims : tuple[int, ...]
-        Dimensions of the array to be loaded or generated.
-    file_path : str | None
-        Path to the directory containing the invariant data files. If None, random data will be generated.
-
-    Returns
-    -------
-    np.ndarray
-        Numpy array containing the invariant data.
-    """
-    if file_path is not None:
-        return xr.open_zarr(
-            file_path
-        ).values  # TODO: fix this after invariant data is available
-    else:
-        return np.random.rand(*dims).astype(np.float32)
-
-
-def create_dummy_metadata(
+def create_metadata(
     variable: str | list[str] | VariableArray,
     conditioning_variable: str | list[str] | VariableArray,
     invariant: str | list[str] | VariableArray,
@@ -200,3 +118,85 @@ def create_dummy_metadata(
     ds = xr.Dataset(data_vars=data_vars, coords=coords)
 
     return ds
+
+
+def prep_metadata_inputs(
+    variable: str | list[str] | VariableArray,
+    conditioning_variable: str | list[str] | VariableArray,
+    invariant: str | list[str] | VariableArray,
+) -> tuple[list[str], list[str], list[str]]:
+    """Simple method to pre-process metadata inputs into a common form
+
+    Parameters
+    ----------
+    variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to variables
+    conditioning_variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to conditioning variables
+    invariant : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to invariant variables
+
+    Returns
+    -------
+    tuple[list[str], list[str], list[str]]
+        Variable, conditioning variable, and invariant lists
+    """
+    if isinstance(variable, str):
+        variable = [variable]
+
+    if isinstance(conditioning_variable, str):
+        conditioning_variable = [conditioning_variable]
+
+    if isinstance(invariant, str):
+        invariant = [invariant]
+
+    return variable, conditioning_variable, invariant
+
+
+def load_means_stds(
+    dims: tuple[int, ...], file_path: str | None
+) -> tuple[np.ndarray, np.ndarray]:
+    """Simple method to load means and standard deviations from .npy files or generate random numpy arrays.
+
+    Parameters
+    ----------
+    dims : tuple[int, ...]
+        Dimensions of the array to be loaded or generated.
+    file_path : str | None
+        Path to the directory containing the means and stds .npy files. If None, random data will be generated.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Tuple containing the means and standard deviations as numpy arrays.
+    """
+    if file_path is not None:
+        means = np.load(f"{file_path}/means.npy")
+        stds = np.load(f"{file_path}/stds.npy")
+    else:
+        means = np.random.rand(*dims).astype(np.float32)
+        stds = np.random.rand(*dims).astype(np.float32) + 0.1
+    return means, stds
+
+
+def load_invariant_data(dims: tuple[int, ...], file_path: str | None) -> np.ndarray:
+    """Simple method to load invariant data from zarr files or generate random numpy arrays.
+
+    Parameters
+    ----------
+    dims : tuple[int, ...]
+        Dimensions of the array to be loaded or generated.
+    file_path : str | None
+        Path to the directory containing the invariant data files. If None, random data will be generated.
+
+    Returns
+    -------
+    np.ndarray
+        Numpy array containing the invariant data.
+    """
+    if file_path is not None:
+        return xr.open_zarr(
+            file_path
+        ).values  # TODO: fix this after invariant data is available
+    else:
+        return np.random.rand(*dims).astype(np.float32)

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -20,6 +20,88 @@ import xarray as xr
 from earth2studio.utils.type import VariableArray
 
 
+def prep_metadata_inputs(
+    variable: str | list[str] | VariableArray,
+    conditioning_variable: str | list[str] | VariableArray,
+    invariant: str | list[str] | VariableArray,
+) -> tuple[list[str], list[str], list[str]]:
+    """Simple method to pre-process metadata inputs into a common form
+
+    Parameters
+    ----------
+    variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to variables
+    conditioning_variable : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to conditioning variables
+    invariant : str | list[str] | VariableArray
+        String, list of strings or array of strings that refer to invariant variables
+
+    Returns
+    -------
+    tuple[list[str], list[str], list[str]]
+        Variable, conditioning variable, and invariant lists
+    """
+    if isinstance(variable, str):
+        variable = [variable]
+
+    if isinstance(conditioning_variable, str):
+        conditioning_variable = [conditioning_variable]
+
+    if isinstance(invariant, str):
+        invariant = [invariant]
+
+    return variable, conditioning_variable, invariant
+
+
+def load_means_stds(
+    dims: tuple[int, ...], file_path: str | None
+) -> tuple[np.ndarray, np.ndarray]:
+    """Simple method to load means and standard deviations from .npy files or generate random numpy arrays.
+
+    Parameters
+    ----------
+    dims : tuple[int, ...]
+        Dimensions of the array to be loaded or generated.
+    file_path : str | None
+        Path to the directory containing the means and stds .npy files. If None, random data will be generated.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Tuple containing the means and standard deviations as numpy arrays.
+    """
+    if file_path is not None:
+        means = np.load(f"{file_path}/means.npy")
+        stds = np.load(f"{file_path}/stds.npy")
+    else:
+        means = np.random.rand(*dims).astype(np.float32)
+        stds = np.random.rand(*dims).astype(np.float32) + 0.1
+    return means, stds
+
+
+def load_invariant_data(dims: tuple[int, ...], file_path: str | None) -> np.ndarray:
+    """Simple method to load invariant data from zarr files or generate random numpy arrays.
+
+    Parameters
+    ----------
+    dims : tuple[int, ...]
+        Dimensions of the array to be loaded or generated.
+    file_path : str | None
+        Path to the directory containing the invariant data files. If None, random data will be generated.
+
+    Returns
+    -------
+    np.ndarray
+        Numpy array containing the invariant data.
+    """
+    if file_path is not None:
+        return xr.open_zarr(
+            file_path
+        ).values  # TODO: fix this after invariant data is available
+    else:
+        return np.random.rand(*dims).astype(np.float32)
+
+
 def create_dummy_metadata(
     variable: str | list[str] | VariableArray,
     conditioning_variable: str | list[str] | VariableArray,
@@ -48,9 +130,9 @@ def create_dummy_metadata(
     x : int
         The number of longitude grid points.
     variable_file_path : str | None
-        Path to the file containing the variable std/mean. If None, the variable std/mean will be randomly generated.
+        Path to the file containing the variable stds/means. If None, the variable stds/means will be randomly generated.
     conditioning_variable_file_path : str | None
-        Path to the file containing the conditioning variable std/mean. If None, the conditioning variable std/mean will be randomly generated.
+        Path to the file containing the conditioning variable stds/means. If None, the conditioning variable stds/means will be randomly generated.
     invariant_file_path : str | None
         Path to the file containing the invariant data. If None, the invariant data will be randomly generated.
 
@@ -61,14 +143,9 @@ def create_dummy_metadata(
 
     """
 
-    if isinstance(variable, str):
-        variable = [variable]
-
-    if isinstance(conditioning_variable, str):
-        conditioning_variable = [conditioning_variable]
-
-    if isinstance(invariant, str):
-        invariant = [invariant]
+    variable, conditioning_variable, invariant = prep_metadata_inputs(
+        variable, conditioning_variable, invariant
+    )
 
     dims = {
         "conditioning_variable": len(conditioning_variable),
@@ -94,30 +171,17 @@ def create_dummy_metadata(
         "y": np.arange(dims["y"]),
     }
 
-    if variable_file_path is not None:
-        variable_means = np.load(f"{variable_file_path}/means.npy")
-        variable_stds = np.load(f"{variable_file_path}/stds.npy")
-    else:
-        variable_means = np.random.rand(dims["variable"]).astype(np.float32)
-        variable_stds = np.random.rand(dims["variable"]).astype(np.float32) + 0.1
+    variable_means, variable_stds = load_means_stds(
+        (dims["variable"],), variable_file_path
+    )
 
-    if conditioning_variable_file_path is not None:
-        conditioning_means = np.load(f"{conditioning_variable_file_path}/means.npy")
-        conditioning_stds = np.load(f"{conditioning_variable_file_path}/stds.npy")
-    else:
-        conditioning_means = np.random.rand(dims["conditioning_variable"]).astype(
-            np.float32
-        )
-        conditioning_stds = (
-            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1
-        )
+    conditioning_means, conditioning_stds = load_means_stds(
+        (dims["conditioning_variable"],), conditioning_variable_file_path
+    )
 
-    if invariant_file_path is not None:
-        invariant_data = xr.open_dataarray(invariant_file_path).values
-    else:
-        invariant_data = np.random.rand(dims["invariant"], dims["y"], dims["x"]).astype(
-            np.float32
-        )
+    invariant_data = load_invariant_data(
+        (dims["invariant"], dims["y"], dims["x"]), invariant_file_path
+    )
 
     data_vars = {
         "conditioning_means": (

--- a/earth2studio/utils/metadata.py
+++ b/earth2studio/utils/metadata.py
@@ -22,12 +22,15 @@ from earth2studio.utils.type import VariableArray
 
 def create_dummy_metadata(
     variable: str | list[str] | VariableArray,
-    conditioning_variable: str | list[str] | VariableArray = "",
-    invariant: str | list[str] | VariableArray = "c",
+    conditioning_variable: str | list[str] | VariableArray,
+    invariant: str | list[str] | VariableArray = [],
     y: int = 32,
     x: int = 32,
+    variable_file_path: str | None = None,
+    conditioning_file_path: str | None = None,
+    invariant_file_path: str | None = None,
 ) -> xr.Dataset:
-    """Creates a dummy metadata xarray dataset with a structure matching the StormCast model's metadata.
+    """Creates a StormCast metadata xarray dataset with a structure matching the StormCast model's metadata.
 
     Parameters
     ----------
@@ -44,11 +47,17 @@ def create_dummy_metadata(
         The number of latitude grid points.
     x : int
         The number of longitude grid points.
+    variable_file_path : str | None
+        Path to the file containing the variable std/mean. If None, the variable std/mean will be randomly generated.
+    conditioning_file_path : str | None
+        Path to the file containing the conditioning variable std/mean. If None, the conditioning variable std/mean will be randomly generated.
+    invariant_file_path : str | None
+        Path to the file containing the invariant data. If None, the invariant data will be randomly generated.
 
     Returns
     -------
     xarray.Dataset
-        A dummy Stormcast metadata xarray dataset
+        A Stormcast metadata xarray dataset
 
     """
 
@@ -56,8 +65,7 @@ def create_dummy_metadata(
         variable = [variable]
 
     if isinstance(conditioning_variable, str):
-        # conditioning_variable = [conditioning_variable]
-        conditioning_variable = []
+        conditioning_variable = [conditioning_variable]
 
     if isinstance(invariant, str):
         invariant = [invariant]
@@ -86,24 +94,47 @@ def create_dummy_metadata(
         "y": np.arange(dims["y"]),
     }
 
+    if variable_file_path is not None:
+        variable_means = xr.open_dataarray(variable_file_path).values
+        variable_std = xr.open_dataarray(variable_file_path).values
+    else:
+        variable_means = np.random.rand(dims["conditioning_variable"]).astype(
+            np.float32
+        )
+        variable_std = (
+            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1
+        )
+
+    if conditioning_file_path is not None:
+        conditioning_means = xr.open_dataarray(conditioning_file_path).values
+        conditioning_std = xr.open_dataarray(conditioning_file_path).values
+    else:
+        conditioning_means = np.random.rand(dims["conditioning_variable"]).astype(
+            np.float32
+        )
+        conditioning_std = (
+            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1
+        )
+
+    if invariant_file_path is not None:
+        invariant_data = xr.open_dataarray(invariant_file_path).values
+    else:
+        invariant_data = np.random.rand(dims["invariant"], dims["y"], dims["x"]).astype(
+            np.float32
+        )
+
     data_vars = {
         "conditioning_means": (
             ("conditioning_variable",),
-            np.random.rand(dims["conditioning_variable"]).astype(np.float32),
+            conditioning_means,
         ),
         "conditioning_stds": (
             ("conditioning_variable",),
-            np.random.rand(dims["conditioning_variable"]).astype(np.float32) + 0.1,
+            conditioning_std,
         ),
-        "invariants": (
-            ("invariant", "y", "x"),
-            np.random.rand(dims["invariant"], dims["y"], dims["x"]).astype(np.float32),
-        ),
-        "means": (("variable",), np.random.rand(dims["variable"]).astype(np.float32)),
-        "stds": (
-            ("variable",),
-            np.random.rand(dims["variable"]).astype(np.float32) + 0.1,
-        ),
+        "invariants": (("invariant", "y", "x"), invariant_data),
+        "means": (("variable",), variable_means),
+        "stds": (("variable",), variable_std),
     }
 
     ds = xr.Dataset(data_vars=data_vars, coords=coords)

--- a/examples/04_corrdiff_inference.py
+++ b/examples/04_corrdiff_inference.py
@@ -37,9 +37,10 @@ In this example you will learn:
 - Initializing and running CorrDiff diagnostic model
 - Post-processing results.
 """
+#   "earth2studio[corrdiff] @ git+https://github.com/NVIDIA/earth2studio.git",
 # /// script
 # dependencies = [
-#   "earth2studio[corrdiff] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[corrdiff] @ file:///home/master/14/andrewhsu/projects/earth2studio/",
 #   "cartopy",
 # ]
 # ///
@@ -200,6 +201,9 @@ io = run(["2023-10-04T18:00:00"], corrdiff, data, io, number_of_samples=1)
 # %%
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
+
+# "lat": np.linspace(19.25, 28, 36, endpoint=True),
+# "lon": np.linspace(116, 126, 40, endpoint=False),
 
 projection = ccrs.LambertConformal(
     central_longitude=io["lon"][:].mean(),

--- a/examples/09-1_stormcast_example.py
+++ b/examples/09-1_stormcast_example.py
@@ -153,10 +153,24 @@ step = 4  # lead time = 1 hr
 plt.close("all")
 
 # Create a correct Lambert Conformal projection
+# The parameters below are derived from the RWRF
+# CEN_LAT: 23.764400482177734
+# CEN_LON: 120.81399536132812
+# TRUELAT1: 10.0
+# TRUELAT2: 40.0
+# MOAD_CEN_LAT: 21.494176864624023
+# STAND_LON: 120.0
+# POLE_LAT: 90.0
+# POLE_LON: 0.0
+# GMT: 0.0
+# JULYR: 2019
+# JULDAY: 215
+# MAP_PROJ: 1
+# MAP_PROJ_CHAR: Lambert Conformal
 projection = ccrs.LambertConformal(
-    central_longitude=126,
-    central_latitude=23,
-    standard_parallels=(23, 23),
+    central_longitude=120.0,
+    central_latitude=21.494176864624023,
+    standard_parallels=(10, 40),
     globe=ccrs.Globe(semimajor_axis=6371229, semiminor_axis=6371229),
 )
 

--- a/examples/09-1_stormcast_example.py
+++ b/examples/09-1_stormcast_example.py
@@ -94,7 +94,7 @@ load_dotenv()  # TODO: make common example prep function
 # import sys
 # sys.exit(0)
 
-from earth2studio.data import RWRF, HRRR
+from earth2studio.data import HRRR, RWRF
 from earth2studio.io import ZarrBackend
 from earth2studio.models.px import StormCastTaiwan
 
@@ -124,7 +124,9 @@ io = ZarrBackend()
 import earth2studio.run as run
 
 nsteps = 4
-dt = datetime(2023, 10, 4) #! Requested date time needs to be after January 1st, 2021 for GFS on AWS
+dt = datetime(
+    2023, 10, 4
+)  #! Requested date time needs to be after January 1st, 2021 for GFS on AWS
 date = dt.isoformat().split("T")[0]
 io = run.deterministic([date], nsteps, model, data, io)
 
@@ -152,9 +154,9 @@ plt.close("all")
 
 # Create a correct Lambert Conformal projection
 projection = ccrs.LambertConformal(
-    central_longitude=262.5,
-    central_latitude=38.5,
-    standard_parallels=(38.5, 38.5),
+    central_longitude=126,
+    central_latitude=23,
+    standard_parallels=(23, 23),
     globe=ccrs.Globe(semimajor_axis=6371229, semiminor_axis=6371229),
 )
 
@@ -167,12 +169,7 @@ im = ax.pcolormesh(
     model.lat,
     io[variable][0, step],
     transform=ccrs.PlateCarree(),
-    cmap="Spectral_r",
-)
-
-# Set state lines
-ax.add_feature(
-    cartopy.feature.STATES.with_scale("50m"), linewidth=0.5, edgecolor="black", zorder=2
+    cmap="RdBu_r",
 )
 
 # Set title

--- a/examples/09-1_stormcast_example.py
+++ b/examples/09-1_stormcast_example.py
@@ -76,36 +76,16 @@ from dotenv import load_dotenv
 
 load_dotenv()  # TODO: make common example prep function
 
-# from netCDF4 import Dataset
-
-# def load_wrf_interp_nc(date_str: str, hr_str: str) -> Dataset:
-#     dt = datetime.strptime(date_str, "%Y/%m/%d")
-#     fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
-#     folder = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
-#     filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp"
-#     if not os.path.exists(filepath):
-#         raise FileNotFoundError(f"File not found: {filepath}")
-#     ds = Dataset(filepath, mode="r")
-#     return ds
-
-# ds = load_wrf_interp_nc("2019/08/03", str(23).zfill(2))
-# logger.info(f"latitude: {ds.variables['XLAT'][:]}, longitude: {ds.variables['XLONG'][:]}")
-
-# import sys
-# sys.exit(0)
-
-from earth2studio.data import ARCO, HRRR, RWRF
+from earth2studio.data import ARCO, RWRF
 from earth2studio.io import ZarrBackend
 from earth2studio.models.px import StormCastTaiwan
 
-# Load the default model package which downloads the check point from NGC
-# Use the default conditioning data source GFS_FX
+# Load the default model package which uses local checkpoint
 package = StormCastTaiwan.load_default_package()
 model = StormCastTaiwan.load_model(package, ARCO())
 
 # Create the data source
 data = RWRF()
-# data = HRRR()
 
 # Create the IO handler, store in memory
 io = ZarrBackend()
@@ -153,7 +133,9 @@ step = 4  # lead time = 1 hr
 plt.close("all")
 
 # Create a correct Lambert Conformal projection
-# The parameters below are derived from the RWRF
+# The parameters below are derived from the RWRF global attributes:
+# data.get_global_attrs()  # Print global attributes for debugging
+# ...
 # CEN_LAT: 23.764400482177734
 # CEN_LON: 120.81399536132812
 # TRUELAT1: 10.0
@@ -167,6 +149,7 @@ plt.close("all")
 # JULDAY: 215
 # MAP_PROJ: 1
 # MAP_PROJ_CHAR: Lambert Conformal
+# ...
 projection = ccrs.LambertConformal(
     central_longitude=120.0,
     central_latitude=21.494176864624023,

--- a/examples/09-1_stormcast_example.py
+++ b/examples/09-1_stormcast_example.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# %%
+"""
+Running StormCast Inference
+===========================
+
+Basic StormCast inference workflow.
+
+This example will demonstrate how to run a simple inference workflow to generate a
+basic determinstic forecast using StormCast. For details about the stormcast model,
+see
+
+ - https://arxiv.org/abs/2408.10958
+
+"""
+#   "earth2studio[data,stormcast] @ git+https://github.com/NVIDIA/earth2studio.git",
+# /// script
+# dependencies = [
+#   "earth2studio[data,stormcast] @ file:///home/master/14/andrewhsu/projects/earth2studio/",
+#   "cartopy",
+# ]
+# ///
+
+# %%
+# Set Up
+# ------
+# All workflows inside Earth2Studio require constructed components to be
+# handed to them. In this example, let's take a look at the most basic:
+# :py:meth:`earth2studio.run.deterministic`.
+
+# %%
+# .. literalinclude:: ../../earth2studio/run.py
+#    :language: python
+#    :start-after: # sphinx - deterministic start
+#    :end-before: # sphinx - deterministic end
+
+# %%
+# Thus, we need the following:
+#
+# - Prognostic Model: Use the built in StormCast Model :py:class:`earth2studio.models.px.StormCast`.
+# - Datasource: Pull data from the HRRR data api :py:class:`earth2studio.data.HRRR`.
+# - IO Backend: Let's save the outputs into a Zarr store :py:class:`earth2studio.io.ZarrBackend`.
+#
+# StormCast also requires a conditioning data source. We use a forecast data source here,
+# GFS_FX :py:class:`earth2studio.data.GFS_FX` which is the default, but a non-forecast
+# data source such as ARCO could also be used with appropriate time stamps.
+
+# %%
+from datetime import datetime, timedelta
+
+from loguru import logger
+from tqdm import tqdm
+
+logger.remove()
+logger.add(lambda msg: tqdm.write(msg, end=""), colorize=True)
+
+import os
+
+os.makedirs("outputs", exist_ok=True)
+from dotenv import load_dotenv
+
+load_dotenv()  # TODO: make common example prep function
+
+# from netCDF4 import Dataset
+
+# def load_wrf_interp_nc(date_str: str, hr_str: str) -> Dataset:
+#     dt = datetime.strptime(date_str, "%Y/%m/%d")
+#     fmt_dt_str = dt.strftime(f"%Y-%m-%d_{int(hr_str):02d}")
+#     folder = "/home/master/14/andrewhsu/projects/physicsnemo/dev/data/rwrf"
+#     filepath = f"{folder}/{fmt_dt_str}/wrfout_d01_{fmt_dt_str}_interp"
+#     if not os.path.exists(filepath):
+#         raise FileNotFoundError(f"File not found: {filepath}")
+#     ds = Dataset(filepath, mode="r")
+#     return ds
+
+# ds = load_wrf_interp_nc("2019/08/03", str(23).zfill(2))
+# logger.info(f"latitude: {ds.variables['XLAT'][:]}, longitude: {ds.variables['XLONG'][:]}")
+
+# import sys
+# sys.exit(0)
+
+from earth2studio.data import RWRF, HRRR
+from earth2studio.io import ZarrBackend
+from earth2studio.models.px import StormCastTaiwan
+
+# Load the default model package which downloads the check point from NGC
+# Use the default conditioning data source GFS_FX
+package = StormCastTaiwan.load_default_package()
+model = StormCastTaiwan.load_model(package)
+
+# Create the data source
+data = RWRF()
+# data = HRRR()
+
+# Create the IO handler, store in memory
+io = ZarrBackend()
+
+# %%
+# Execute the Workflow
+# --------------------
+# With all components initialized, running the workflow is a single line of Python code.
+# Workflow will return the provided IO object back to the user, which can be used to
+# then post process. Some have additional APIs that can be handy for post-processing or
+# saving to file. Check the API docs for more information.
+#
+# For the forecast we will predict for 4 hours
+
+# %%
+import earth2studio.run as run
+
+nsteps = 4
+dt = datetime(2023, 10, 4) #! Requested date time needs to be after January 1st, 2021 for GFS on AWS
+date = dt.isoformat().split("T")[0]
+io = run.deterministic([date], nsteps, model, data, io)
+
+print(io.root.tree())
+
+# %%
+# Post Processing
+# ---------------
+# The last step is to post process our results. Cartopy is a great library for plotting
+# fields on projections of a sphere. Here we will just plot the temperature at 2 meters
+# (t2m) 4 hours into the forecast.
+#
+# Notice that the Zarr IO function has additional APIs to interact with the stored data.
+
+# %%
+import cartopy
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+
+forecast = f"{date}"
+variable = "t2m"
+step = 4  # lead time = 1 hr
+
+plt.close("all")
+
+# Create a correct Lambert Conformal projection
+projection = ccrs.LambertConformal(
+    central_longitude=262.5,
+    central_latitude=38.5,
+    standard_parallels=(38.5, 38.5),
+    globe=ccrs.Globe(semimajor_axis=6371229, semiminor_axis=6371229),
+)
+
+# Create a figure and axes with the specified projection
+fig, ax = plt.subplots(subplot_kw={"projection": projection}, figsize=(10, 6))
+
+# Plot the field using pcolormesh
+im = ax.pcolormesh(
+    model.lon,
+    model.lat,
+    io[variable][0, step],
+    transform=ccrs.PlateCarree(),
+    cmap="Spectral_r",
+)
+
+# Set state lines
+ax.add_feature(
+    cartopy.feature.STATES.with_scale("50m"), linewidth=0.5, edgecolor="black", zorder=2
+)
+
+# Set title
+ax.set_title(f"{forecast} {variable} - Lead time: {step}hrs")
+
+# Add coastlines and gridlines
+ax.coastlines()
+ax.gridlines()
+plt.savefig(f"outputs/09_{date}_t2m_prediction.jpg")

--- a/examples/09-1_stormcast_example.py
+++ b/examples/09-1_stormcast_example.py
@@ -94,14 +94,14 @@ load_dotenv()  # TODO: make common example prep function
 # import sys
 # sys.exit(0)
 
-from earth2studio.data import HRRR, RWRF
+from earth2studio.data import ARCO, HRRR, RWRF
 from earth2studio.io import ZarrBackend
 from earth2studio.models.px import StormCastTaiwan
 
 # Load the default model package which downloads the check point from NGC
 # Use the default conditioning data source GFS_FX
 package = StormCastTaiwan.load_default_package()
-model = StormCastTaiwan.load_model(package)
+model = StormCastTaiwan.load_model(package, ARCO())
 
 # Create the data source
 data = RWRF()

--- a/examples/09_stormcast_example.py
+++ b/examples/09_stormcast_example.py
@@ -28,9 +28,10 @@ see
  - https://arxiv.org/abs/2408.10958
 
 """
+#   "earth2studio[data,stormcast] @ git+https://github.com/NVIDIA/earth2studio.git",
 # /// script
 # dependencies = [
-#   "earth2studio[data,stormcast] @ git+https://github.com/NVIDIA/earth2studio.git",
+#   "earth2studio[data,stormcast] @ file:///home/master/14/andrewhsu/projects/earth2studio/",
 #   "cartopy",
 # ]
 # ///
@@ -78,10 +79,14 @@ load_dotenv()  # TODO: make common example prep function
 from earth2studio.data import HRRR
 from earth2studio.io import ZarrBackend
 from earth2studio.models.px import StormCast
+from earth2studio.models.auto import Package
 
 # Load the default model package which downloads the check point from NGC
 # Use the default conditioning data source GFS_FX
-package = StormCast.load_default_package()
+package = Package(
+    "/home/master/13/dczy/stormcast-v1-era5-hrrr_v1.0.1",
+    cache=False,
+)
 model = StormCast.load_model(package)
 
 # Create the data source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,9 @@ docs = [
 [tool.hatch.version]
 path = "earth2studio/__init__.py"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.sdist]
 include = ["earth2studio/**/*.py"]
 exclude = []


### PR DESCRIPTION
## Description

This PR adds support for running **era5-rwrf stormcast inference** using the `examples/09-1_stormcast_example.py` script, specifically tailored to the requirements of the `stormcast-v1-era5-hrrr_v1.0.1` checkpoint in `/home/master/13/dczy/stormcast-v1-era5-hrrr_v1.0.1`. See #2 for details about `conditioning_variables` and `invariants`

**Preconditions:**
- Ensures inference resolution matches the trained checkpoint (**32x32**).
- Plots results for the region centered on **National Taiwan University** (25.0173° N, 121.5398° E).
- Align variables, conditioning variables, and invariants with @desmondc65's checkpoint:
  - `variables = ["t2m"]`
  - `conditioning_variables = ["t2m"]`
  - `invariants = []`
- __Doesn't support multiple dates for RWRF__, currently only support `2019/08/03` , default is 2019/08/03:00
- Needs variable and conditioning variable means/stds .npy files (used in `earth2studio/utils/metadata.py`) and desired `RWRF` dataset (update in `RWRF`'s `__init__`) before inference 

## Steps to Reproduce Below Result

1. **Update Local Paths:**
   Update all local file paths (e.g., `file:///home/master/14/andrewhsu/projects/earth2studio/`) in the script dependencies of the following scripts to match your environment:
   - `examples/04_corrdiff_inference.py`
   - `examples/09_stormcast_example.py`
   - `examples/09-1_stormcast_example.py`
     *Note: To reproduce the results below, you only need to update `examples/09-1_stormcast_example.py`.*
2. **Load Checkpoints/Config:**
   Download checkpoints and configs from @desmondc65 (at google drive) and place them in the `checkpoints` folder as follows:
   ```
   checkpoints
   ├── rundir_dif_0710_24hrs
   └── rundir_reg_0710_24hrs
   ```
   Update the `from_checkpoint` path in the `load_model` method of `StormCastTaiwan` to reflect your local path.
3. **Dataset Path:**
   Ensure you have the desired `RWRF` dataset and update its local path in the `__init__` method of `RWRF`.
4. **Metadata Paths:**
   Provide the full day (0-23 hrs) conditioning variable means/std and variable means/std for the desired date, and update their local paths in the `create_metadata` method within `load_model` in `StormCastTaiwan`.
   *Note: The result below uses `2019/08/03:00` t2m var which is also the default.*
5. Make sure you are in the root directory of the **earth2studio** project.
6. Update the local file paths in the `run` command of the `Makefile`.
   Then run:
   ```
   make run
   ```
   This will execute `examples/09-1_stormcast_example.py`.
   *Tip: Adjust `09-1-stormcast-example-*` and the script path if you want to run different scripts.*

## Results
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/104f3a90-c7d9-4885-b618-29268378e077" />

## Changes

- **`earth2studio/data/rwrf.py`**
  - Implements a dataset class similar to `HRRR`, but for the local `RWRF` dataset.
  - `__init__`: Initializes RWRF dataset paths based on date, hour, and source folder.
  - `fetch`: Loads RWRF data into an xarray structure consistent with HRRR.
  - `available`, `_validate_time`, `_range`: **TODO: Update after confirming RWRF intervals and dates.**
  - `get_global_attrs`: Helper to retrieve RWRF global attributes.
  - `get_lat_lon_bound`: Helper to extract RWRF SW/NW/NE/SE lat/lon bounds.
  - `get_corresponding_indices`: Finds closest RWRF grid indices for a given lat/lon.

- **`earth2studio/models/auto/package.py`**
  - Uses `/home` prefix to detect local checkpoints for now.
    **TODO:** Implement a custom local package.

- **`earth2studio/models/px/stormcast.py`**
  - Adds `StormCastTaiwan`, which supports Taiwan lat/lon coordinates; methods are similar to `StormCast`.
  - `__init__`: the `rwrf_lat/lon_lims` are `RWRF.grid()` indices (32x32) default to centered at National Taiwan University
  - `load_default_package`: Updated to load local package.
    *(Note: Currently not a custom package; will need to implement this in the future.)*
  - `load_model`: Loads local checkpoints and constructs metadata in the same structure as the default `StormCast` package.
  - `_forward`: Adds debug logs to trace tensor shapes.

- **`earth2studio/utils/metadata.py`**
  - Creates custom metadata with the same structure as the [original metadata](https://github.com/running-berry/earth2studio/blob/59230b407e61e943ed7983d2685e0a82f534dff4/earth2studio/models/px/stormcast.py#L293).
   *Note: `lat`/`lon` values here are overwritten in `StormCastTaiwan.__init__`.*

- **`pyproject.toml`**
  - Adds a direct reference (see [comment](https://github.com/running-berry/physicsnemo/pull/30#issue-3284603088) for more details).

- **`Makefile`**
  - Adds command to run `examples/09-1_stormcast_example.py`.
    **TODO:** Find a more flexible/clean way to run scripts.

- **Examples**
  * `examples/09_stormcast_example.py` & `examples/04_corrdiff_inference.py`: Update paths to use local data.
    **TODO:** Streamline script execution.
  * `examples/09-1_stormcast_example.py`: Script for running ERA5-RWRF StormCast inference.
    * Similar to `09_stormcast_example.py` but uses `ARCO` as the data source (instead of `GFS_FX`).
      *Tip: Use ERA5 to reconstruct past events, GFS\_FX for forecasts.*
    * Loads `LCC` parameters from RWRF's global attributes.

## Future Improvements

- [ ] Standardize and update all docstrings for `StormCastTaiwan` and `RWRF`.
- [ ] Remove unused async workflows (e.g., workers) from `RWRF`.
- [ ] Add support for loading multiple dates in `RWRF`, and fix the `_range`, `_validate_time`, and `available` methods.
- [x] Build a fully custom local package (have `EDMPrecond` and `StormCastUNet`—still need `metadata.zarr.zip` and `model.yaml`). Update `load_default_package` and `load_model` in `StormCastTaiwan` accordingly.
- [ ] Verify whether `ARCO` is the correct data source for this use case.
- [ ] Clean up and remove unnecessary debug logs.


## Reference
https://github.com/running-berry/physicsnemo/issues/28, #2 